### PR TITLE
Rebuild Markdown Manual

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
         version: 3.2
 
     - name: Build
-      run: make -C man man
+      run: make -C man all

--- a/Makefile
+++ b/Makefile
@@ -34,66 +34,75 @@ PRECOMMIT ?= pre-commit
 
 ### Sources
 
-## Standard Targets
+#. STANDARD TARGETS
 
 .PHONY: all clean install test uninstall
-all:
+all: #> Build everything
 	$(MAKE) -C man all
 	$(MAKE) -C src all
 
-clean: pre-commit-clean
+clean: pre-commit-clean #> Remove files built by running make earlier
 	$(MAKE) -C man clean
 	$(MAKE) -C src clean
 
-install:
+install: #> Install programs and manuals made here
 	$(MAKE) -C man install
 	$(MAKE) -C src install
 
-test: pre-commit-run
+test: pre-commit-run #> Run all tests and checks
 	$(MAKE) -C man test
 	$(MAKE) -C src test
 
-uninstall:
+uninstall: #> Uninstall programs and manuals made here
 	$(MAKE) -C man uninstall
 	$(MAKE) -C src uninstall
 
-## Other Targets
+#. OTHER TARGETS
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug
+debug: path-debug #> Show debugging information
 	$(MAKE) -C man debug
 	$(MAKE) -C src debug
 
-.NOTPARALLEL: install-dependencies
-.PHONY: install-dependencies
-install-dependencies: brew-developer-install brew-user-install pre-commit-install
+# https://stackoverflow.com/a/47107132/112682
+.PHONY: help
+help: #> Show this help
+	@sed -n \
+		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/:.*#> /:/p' \
+		$(MAKEFILE_LIST) \
+		| column -ts :
+
+#. HOMEBREW TARGETS
+
+.NOTPARALLEL: brew-install
+.PHONY: brew-install
+brew-install: brew-developer-install brew-user-install pre-commit-install #> Install depenedencies with Homebrew
 	@:
 
-### homebrew targets
-
 .PHONY: brew-developer-install
-brew-developer-install:
+brew-developer-install: #> Use HomeBrew to install dependencies that developers need to work here
 	$(BREW) bundle install --file=./etc/macos/Brewfile.developer
 
 .PHONY: brew-user-install
-brew-user-install:
+brew-user-install: #> Use HomeBrew to install dependencies that users need to run this
 	$(BREW) bundle install --file=./etc/macos/Brewfile.user
 
-### pre-commit targets
+#. PRE-COMMIT TARGETS
 
 .PHONY: pre-commit-clean
-pre-commit-clean:
+pre-commit-clean: #> Remove pre-commit files that are no longer referenced
 	$(PRECOMMIT) gc
 
 .PHONY: pre-commit-install
-pre-commit-install:
+pre-commit-install: #> Install Git hooks
 	$(PRECOMMIT) install
 
 .PHONY: pre-commit-run
-pre-commit-run:
+pre-commit-run: #> Run pre-commit hooks on all Git files
 	$(PRECOMMIT) run --all-files
 
 .PHONY: pre-commit-update
-pre-commit-update:
+pre-commit-update: #> Update pre-commit plugins
 	$(PRECOMMIT) autoupdate

--- a/doc/cicd-jobs.md
+++ b/doc/cicd-jobs.md
@@ -4,7 +4,7 @@ Jobs are run with GitHub Actions.
 
 ## `build`
 
-- [Build manuals](./task-automation.md#manual-page-targets)
+- [Build manuals](./task-automation.md#targets-in-man)
 - Run [`pre-commit`](./tools.md#pre-commit) checks.
 
 ### Files

--- a/doc/task-automation.md
+++ b/doc/task-automation.md
@@ -8,93 +8,44 @@ This project uses GNU Make to automate tasks.
 - Use variables for the names of external programs like `fswatch`, with reasonable defaults.
 - Use [standard targets][gnu-standard-targets].  Create separate Makefiles for sub-directories that
   have their own work.
+- Add self-documenting [`help`](https://stackoverflow.com/a/47107132/112682), for relevant targets.
 
 [gnu-directory-variables]: https://www.gnu.org/software/make/manual/make.html#Directory-Variables
 [gnu-standard-targets]:
     https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html#Standard-Targets
 
-## Standard Targets
+## Artifacts
 
-Each `Makefile` contains a set of standard targets.  Each of these targets in the root `Makefile`
-calls `make` with the same target, in sub-directories that have their own `Makefile`.
+### Targets in `man/`
 
-### `make all`
+Manuals are written in Markdown.  This project uses Pandoc to generate `groff` manual pages and
+Markdown manuals in `man/groff/` and `man/markdown/`, respectively.  The Markdown manuals are
+included in the repository, for ease of reading on GitHub.
 
-Build everything except documentation.
+### Targets in `src/`
 
-### `make clean`
+There isn't anything to build, since the programs are all scripts.  However, there are conventional
+targets to install symlinks to the user's `PATH`.
 
-Remove files that were built by running `make` earlier.
+## Development Environment
 
-### `make install`
+### Homebrew Targets
 
-Install all programs and manuals that are made here.
+Makefiles include targets to ease the process of installing dependencies, via HomeBrew.
 
-### `make test`
+### `pre-commit` Targets
 
-Run all tests and checks.
+Makefiles include targets to ease the process of running various checks on project sources with
+[`pre-commit`](./tools.md#pre-commit).
 
-### `make uninstall`
+## Help
 
-Uninstall all programs and manuals made in this repository.
+Use the `help` target to list relevant targets in each `Makefile`:
 
-## Homebrew Targets
+```sh
+# List targets in root Makefile
+make help
 
-### `make brew-developer-install`
-
-Install homebrew packages in `Brewfile.developer` that developers need to work on this project.
-
-### `make brew-user-install`
-
-Install homebrew packages in `Brewfile.user` that users need to run the programs built here.
-
-## Manual Page Targets
-
-A separate `man/Makefile` builds manuals.  It converts Pandoc sources to man pages (e.g. `groff` or
-`troff`) and to basic Markdown, in `man/groff` and `man/markdown`, respectively.  It has some custom
-targets:
-
-### `make groff-manual-preview`
-
-Convert and render manuals as man pages, without installing them anywhere.
-
-### `make groff-manual-watch`
-
-Watch Pandoc source files and render previews of them when they change.
-
-### `make install`
-
-Install man pages to `$(mandir)`.
-
-### `make man`
-
-Build all manuals.
-
-## Other Targets
-
-### `make debug`
-
-Print debugging information, such as the values of variables that affect the build.
-
-## `pre-commit` Targets
-
-### `make pre-commit-clean`
-
-Remove unused tools that were installed by `pre-commit`.
-
-### `make pre-commit-install`
-
-Install Git hooks for `pre-commit`.
-
-### `make pre-commit-run`
-
-Run all `pre-commit` checks on all repository files.
-
-### `make pre-commit-update`
-
-Update `pre-commit` plugins.
-
-## Program Targets
-
-A separate `src/Makefile` handles program sources.  It includes conventional targets that install
-symlinks to programs in `$(bindir)`.
+# List targets for specific sources
+make -C man help
+```

--- a/man/Makefile
+++ b/man/Makefile
@@ -51,40 +51,47 @@ source-debug:
 	$(info - sources_man1: $(sources_man1))
 	$(info - sources_man7: $(sources_man7))
 
-## Standard Targets
+#. STANDARD TARGETS
 
 .PHONY: all clean install test uninstall
-all:
+all: groff-manual markdown-manual #> Build all manuals
 	@:
 
-clean: groff-manual-clean markdown-manual-clean
+clean: groff-manual-clean markdown-manual-clean #> Remove built manuals
+	@:
 
-install: groff-manual-install
+install: groff-manual-install #> Install man pages to $(mandir)
+	@:
 
 test:
 	@:
 
-uninstall: groff-manual-uninstall
+uninstall: groff-manual-uninstall #> Uninstall man pages
+	@:
 
-## Other Targets
+#. OTHER TARGETS
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug source-debug groff-manual-debug markdown-manual-debug
+debug: path-debug source-debug groff-manual-debug markdown-manual-debug #> Show debugging information
 	@:
 
-.PHONY: man
-man: groff-manual markdown-manual
-	@:
+.PHONY: help
+help: #> Show this help
+	@sed -n \
+		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/:.*#> /:/p' \
+		$(MAKEFILE_LIST) \
+		| column -ts :
 
-### groff manual (e.g. man pages) targets
+#. GROFF MANUAL TARGETS
 
 groff_manual_installed := $(wildcard $(man1dir)/marmot* $(man7dir)/marmot*)
 groff_man1_objects := $(patsubst pandoc/%.md,groff/%,$(sources_man1))
 groff_man7_objects := $(patsubst pandoc/%.md,groff/%,$(sources_man7))
 
 .PHONY: groff-manual
-groff-manual: $(groff_man1_objects) $(groff_man7_objects)
+groff-manual: $(groff_man1_objects) $(groff_man7_objects) #> Build man pages
 
 .PHONY: groff-manual-clean
 groff-manual-clean:
@@ -104,7 +111,7 @@ groff-manual-install: $(groff_man1_objects) $(groff_man7_objects)
 	install -g 0 -o 0 -m 0644 $(groff_man7_objects) $(man7dir)
 
 .PHONY: groff-manual-preview
-groff-manual-preview:
+groff-manual-preview: #> Render man pages without building or installing
 	$(PANDOC) $(sources) $(PANDOCFLAGS) -s -t man \
 		| $(MANDOC)
 
@@ -113,7 +120,7 @@ groff-manual-uninstall:
 	$(RM) $(groff_manual_installed)
 
 .PHONY: groff-manual-watch
-groff-manual-watch:
+groff-manual-watch: #> Emit rendered man pages when Pandoc sources change
 	$(FSWATCH) $(sources) \
 		| xargs -I {} echo "$(PANDOC) {} $(PANDOCFLAGS) -s -t man | $(MANDOC)" \
 		| sh
@@ -121,13 +128,13 @@ groff-manual-watch:
 groff/%: pandoc/%.md
 	$(PANDOC) $< $(PANDOCFLAGS) -o $@ -s -t man
 
-### markdown manual targets
+#. MARKDOWN MANUAL TARGETS
 
 markdown_manual_objects := $(patsubst pandoc/%.md,markdown/%.md,$(sources))
 markdown_manual_objects_dir := markdown
 
 .PHONY: markdown-manual
-markdown-manual: $(markdown_manual_objects)
+markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are part of this repo
 
 .PHONY: markdown-manual-clean
 markdown-manual-clean:

--- a/man/markdown/marmot-category-add.1.md
+++ b/man/markdown/marmot-category-add.1.md
@@ -2,47 +2,39 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-CATEGORY-ADD(1) Version 0.6.1 \| Meta Repo Management
-  Tool'
+title: MARMOT-CATEGORY-ADD(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot category add** - Add repositories to a category
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot category add** \[**\--help**\]\
 **marmot category add** *category* *repository* \[...\]\
 **marmot category add** *category*/*sub-category* *repository* \[...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot category add** adds each *repository* to a *category* or
 *sub-category*. Add a **/** between *category* and *sub-category*, to
 work within a sub-category.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -50,23 +42,21 @@ Success
 1+  
 Invalid command or command failure
 
-EXAMPLE
-=======
+# EXAMPLE
 
 Add a repository to the "user" category:
 
-``` {.sh}
+``` sh
 marmot category add user ~/git/dotfiles
 ```
 
 Add some repositories to the "wily" project (lookout Dr. Light):
 
-``` {.sh}
+``` sh
 marmot category add project/wily ~/git/robot-masters ~/git/skull-fortress
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md)

--- a/man/markdown/marmot-category-create.1.md
+++ b/man/markdown/marmot-category-create.1.md
@@ -2,45 +2,38 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-CATEGORY-CREATE(1) Version 0.6.1 \| Meta Repo Management
-  Tool'
+title: MARMOT-CATEGORY-CREATE(1) Version 0.6.1 \| Meta Repo Management
+  Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot category create** - Create a category
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot category create** \[**\--help**\]\
 **marmot category create** *category* \[*sub-category* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot category create** creates a new *category* and each given
 *sub-category*, then adds a directory for each to the Meta Repo.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -48,31 +41,29 @@ Success
 1+  
 Invalid command or command failure
 
-EXAMPLE
-=======
+# EXAMPLE
 
 Create a "lang" category with sub-categories "java" and "typescript":
 
-``` {.sh}
+``` sh
 marmot category create lang java typescript
 ```
 
-Create a "platform" category with sub-categories "beam,"clr","jvm",
-and"node\":
+Create a "platform" category with sub-categories "beam,"clr", "jvm", and
+"node":
 
-``` {.sh}
+``` sh
 marmot category create platform beam clr jvm node
 ```
 
 Create a "project" category with sub-categories "dotnet-8-migration" and
 "skunkworks":
 
-``` {.sh}
+``` sh
 marmot category create project dotnet-8-migration skunkworks
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md)

--- a/man/markdown/marmot-category-list.1.md
+++ b/man/markdown/marmot-category-list.1.md
@@ -2,45 +2,38 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-CATEGORY-LIST(1) Version 0.6.1 \| Meta Repo Management
-  Tool'
+title: MARMOT-CATEGORY-LIST(1) Version 0.6.1 \| Meta Repo Management
+  Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot category list** - List categories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot category list** \[**\--help**\]\
 **marmot category list**
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot category list** lists the categories that are used to group
 repositories.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -48,8 +41,7 @@ Success
 1+  
 Invalid command or command failure
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md)

--- a/man/markdown/marmot-category-rm.1.md
+++ b/man/markdown/marmot-category-rm.1.md
@@ -2,47 +2,39 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-CATEGORY-RM(1) Version 0.6.1 \| Meta Repo Management
-  Tool'
+title: MARMOT-CATEGORY-RM(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot category rm** - Remove repositories from a category
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot category rm** \[**\--help**\]\
 **marmot category rm** *category* *repository* \[...\]\
 **marmot category rm** *category*/*sub-category* *repository* \[...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot category rm** removes each *repository* from a *category* or
 *sub-category*. Add a **/** between *category* and *sub-category*, to
 work within a sub-category.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-category(1)*](./marmot-category.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -50,18 +42,16 @@ Success
 1+  
 Invalid command or command failure
 
-EXAMPLE
-=======
+# EXAMPLE
 
 Remove a newly-categorized repository from the "inbox" category:
 
-``` {.sh}
+``` sh
 marmot category add lang/shiny ~/git/what-is-this
 marmot category rm inbox ~/git/what-is-this
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md)

--- a/man/markdown/marmot-category.1.md
+++ b/man/markdown/marmot-category.1.md
@@ -2,34 +2,29 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-CATEGORY(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-CATEGORY(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot category** - Work with categories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot category** \[**\--help**\]\
 **marmot category** *sub-command* \[*args* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot category** runs the given *sub-command* with any *args*, to do
 something with categories.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-SUB-COMMANDS
-============
+# SUB-COMMANDS
 
 [**add**](./marmot-category-add.1.md)  
 Add repositories to a category
@@ -43,20 +38,17 @@ List categories
 [**rm**](./marmot-category-rm.1.md)  
 Remove repositories from a category
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path to the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Each category and references to their repositories
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -64,8 +56,7 @@ Success
 1+  
 Invalid command
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category-add(1)*](./marmot-category-add.1.md),

--- a/man/markdown/marmot-exec.1.md
+++ b/man/markdown/marmot-exec.1.md
@@ -2,24 +2,21 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-EXEC(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-EXEC(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot exec** - Execute a command in multiple repositories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot exec** \[**\--help**\]\
 **marmot exec** \[**\--category** *category*\|*sub-category*\]
 \[**\--direnv**\] \[**\--repo-names** **heading**\|**inline**\]
 *shell-command* \[*args* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot exec** repeats a given *shell-command* with any *args* on each
 matching repository. The repositories are either all registered
@@ -33,8 +30,7 @@ environment when changing directories. The usefulness of the shell
 command may depend upon it, for example when checking if all
 repositories in a project use the same version of Node.js.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--direnv**  
 Suppress `direnv` output when changing directories
@@ -46,20 +42,17 @@ Show help
 Print repository names **inline** prior to output from *shell-command*,
 or as a **heading** above it
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path to the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Categories and registered repositories
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -67,15 +60,13 @@ Success
 1+  
 Invalid command or **shell-command** failure
 
-NOTES
-=====
+# NOTES
 
-`direnv`
---------
+## `direnv`
 
 Suppress `direnv` output by setting `DIRENV_LOG_FORMAT=`.
 
-``` {.sh}
+``` sh
 $ marmot exec --direnv node --version
 /Users/developer/git/website-api: v14.18.1
 /Users/developer/git/website-app: v20.11.1
@@ -83,60 +74,54 @@ $ marmot exec --direnv node --version
 
 Source: <https://github.com/direnv/direnv/wiki/Quiet-or-Silence-direnv>
 
-Git
----
+## Git
 
 Add `--no-pager` to git commands that pipe to less (and pause for
 input).
 
-EXAMPLE
-=======
+# EXAMPLE
 
-Scanning
---------
+## Scanning
 
 Node: List version of Node.js used in repositories that use direnv+nvm:
 
-``` {.sh}
+``` sh
 marmot exec --category platform/node --direnv \
   node --version
 ```
 
-Searching and Tracing
----------------------
+## Searching and Tracing
 
 Git: Grep for matching source code in all repositories:
 
-``` {.sh}
+``` sh
 marmot exec --category project/robot-masters --repo-names heading \
   git --no-pager grep dungeonType
 ```
 
-Unified Work
-------------
+## Unified Work
 
 Git: Check which branches are checked out right now:
 
-``` {.sh}
+``` sh
 marmot exec --category project/too-many-microservices \
   git branch --show-current
 ```
 
 Git: Pull all the things!
 
-``` {.sh}
+``` sh
 marmot exec --repo-names heading \
   git pull --ff-only origin
 ```
 
 Git: Push all the things!
 
-``` {.sh}
+``` sh
 marmot exec --repo-names heading \
   git push
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot(7)*](./marmot.7.md)

--- a/man/markdown/marmot-init.1.md
+++ b/man/markdown/marmot-init.1.md
@@ -2,46 +2,39 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-INIT(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-INIT(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot init** - Initialize a meta repo
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot init** \[**\--help**\]\
 **marmot init**
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 Initialize a blank Meta Repo in the configured directory, if none is
 already present.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path in which to create the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Blank metadata with no registered repositories or categories
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -49,7 +42,6 @@ Success
 1+  
 Invalid command, command failure, or meta repo already exists
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot(7)*](./marmot.7.md)

--- a/man/markdown/marmot-meta-home.1.md
+++ b/man/markdown/marmot-meta-home.1.md
@@ -2,43 +2,36 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-META-HOME(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-META-HOME(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot meta home** - Show path to Meta Repo
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot meta home** \[**\--help**\]\
 **marmot meta home**
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot meta home** prints the base directory of the Meta Repo.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-meta(1)*](./marmot-meta.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-meta(1)*](./marmot-meta.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -46,8 +39,7 @@ Success
 1+  
 Invalid command or command failure
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot-meta(1)*](./marmot-meta.1.md)
 

--- a/man/markdown/marmot-meta.1.md
+++ b/man/markdown/marmot-meta.1.md
@@ -2,52 +2,44 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-META(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-META(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot meta** - Information about the meta repo
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot meta** \[**\--help**\]\
 **marmot meta** *sub-command* \[*args* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot meta** runs the given *sub-command* with any *args* to do
 something on the Meta Repo.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-SUB-COMMANDS
-============
+# SUB-COMMANDS
 
 [**home**](./marmot-meta-home.1.md)  
 Show the base directory of the Meta Repo
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path to the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Each category and references to their repositories
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -55,8 +47,7 @@ Success
 1+  
 Invalid command
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-meta-home(1)*](./marmot-meta-home.1.md)

--- a/man/markdown/marmot-repo-list.1.md
+++ b/man/markdown/marmot-repo-list.1.md
@@ -2,29 +2,25 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-REPO-LIST(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-REPO-LIST(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot repo list** - List repositories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot repo list** \[**\--help**\]\
 **marmot repo list** \[**\--category** *category*\|*sub-category*\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot repo list** lists repositories that have been registered with
 Marmot. Given options, this lists only the repositories that match the
 given criteria.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--category**  
 List repositories that have been added to the given *category* or
@@ -33,18 +29,15 @@ List repositories that have been added to the given *category* or
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -52,17 +45,15 @@ Success
 1+  
 Invalid command or command failure
 
-EXAMPLE
-=======
+# EXAMPLE
 
 List registered TypeScript repositories
 
-``` {.sh}
+``` sh
 marmot repo list --category lang/typescript
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot-repo(1)*](./marmot-repo.1.md)
 

--- a/man/markdown/marmot-repo-prune.1.md
+++ b/man/markdown/marmot-repo-prune.1.md
@@ -2,22 +2,19 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-REPO-PRUNE(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-REPO-PRUNE(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot repo prune** - Prune references to missing repositories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot repo prune** \[**\--help**\]\
 **marmot repo prune**
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot repo prune** removes references to repositories that are no
 longer where they used to be, when they were registered with
@@ -26,24 +23,20 @@ by checking each registered repository path. Any path that is not a
 directory is removed from registered repositories and from any
 categories that included it.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -51,8 +44,7 @@ Success
 1+  
 Invalid command or command failure
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md),

--- a/man/markdown/marmot-repo-register.1.md
+++ b/man/markdown/marmot-repo-register.1.md
@@ -2,23 +2,20 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-REPO-REGISTER(1) Version 0.6.1 \| Meta Repo Management
-  Tool'
+title: MARMOT-REPO-REGISTER(1) Version 0.6.1 \| Meta Repo Management
+  Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot repo register** - Register repositories to manage
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot repo register** \[**\--help**\]\
 **marmot repo register** *repository-path* \[...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot repo register** registers the each given *repository-path*, so
 **marmot** can start to categorize and operate upon them.
@@ -28,24 +25,20 @@ DESCRIPTION
 repository. *repository-path* may also end in `.git` or `.git/` to ease
 the process of finding and registering lots of Git repositories at once.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-FILES
-=====
+# FILES
 
 See [*marmot-repo(1)*](./marmot-repo.1.md).
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -53,18 +46,16 @@ Success
 1+  
 Invalid command or command failure
 
-EXAMPLE
-=======
+# EXAMPLE
 
 Register all the things!
 
-``` {.sh}
+``` sh
 find ~/git -type d -name .git \
   -exec marmot repo register {} +
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot-repo(1)*](./marmot-repo.1.md)
 

--- a/man/markdown/marmot-repo.1.md
+++ b/man/markdown/marmot-repo.1.md
@@ -2,34 +2,29 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT-REPO(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT-REPO(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot repo** - Work with repositories
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot repo** \[**\--help**\]\
 **marmot repo** *sub-command* \[*args* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot repo** runs the given *sub-command* with any *args* to do
 something with repositories.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
 
-SUB-COMMANDS
-============
+# SUB-COMMANDS
 
 [**list**](./marmot-repo-list.1.md)  
 List repositories
@@ -40,20 +35,17 @@ Prune references to missing repositories
 [**register**](./marmot-repo-register.1.md)  
 Register repositories to manage
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path to the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Repositories that **marmot** knows about
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -61,8 +53,7 @@ Success
 1+  
 Invalid command
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-repo-list(1)*](./marmot-repo-list.1.md),

--- a/man/markdown/marmot.1.md
+++ b/man/markdown/marmot.1.md
@@ -2,27 +2,23 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT(1) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT(1) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-```{=html}
 <!---
 man-pages reference: https://linux.die.net/man/7/man-pages
 -->
-```
-NAME
-====
+
+# NAME
 
 **marmot** - Meta Repo Management Tool
 
-SYNOPSIS
-========
+# SYNOPSIS
 
 **marmot** \[**\--help**\] \[**\--version**\]\
 **marmot** *command* \[*args* ...\]
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 Run the **marmot** *command* with any *args* to interact with the Meta
 Repo or the repositories it tracks, in some way. See
@@ -33,8 +29,7 @@ other Git repositories that are grouped into 1 or more categories.
 **marmot** helps you work with all the repositories in a category, as if
 they are a single unit. See [*marmot(7)*](./marmot.7.md) to get started.
 
-OPTIONS
-=======
+# OPTIONS
 
 **\--help**  
 Show help
@@ -42,11 +37,9 @@ Show help
 **\--version**  
 Prints the **marmot** suite version that the program came from
 
-COMMANDS
-========
+# COMMANDS
 
-Meta Repo Commands
-------------------
+## Meta Repo Commands
 
 [**init**](./marmot-init.1.md)  
 Create a new meta repo
@@ -54,14 +47,12 @@ Create a new meta repo
 [**meta**](./marmot-meta.1.md)  
 Information about the meta repo itself
 
-Category commands
------------------
+## Category commands
 
 [**category**](./marmot-category.1.md)  
 Work with categories
 
-Repository Commands
--------------------
+## Repository Commands
 
 [**exec**](./marmot-exec.1.md)  
 Execute a shell command in multiple repositories
@@ -69,20 +60,17 @@ Execute a shell command in multiple repositories
 [**repo**](./marmot-repo.1.md)  
 Work with repositories
 
-ENVIRONMENT VARIABLES
-=====================
+# ENVIRONMENT VARIABLES
 
-**MARMOT\_META\_REPO**  
+**MARMOT_META_REPO**  
 Path to the Meta Repo (default: \$HOME/meta)
 
-FILES
-=====
+# FILES
 
-*\$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
 Registered repositories and how they relate to one another
 
-EXIT STATUS
-===========
+# EXIT STATUS
 
 0  
 Success
@@ -90,8 +78,7 @@ Success
 1+  
 Invalid command or command failure
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot-category(1)*](./marmot-category.1.md),
 [*marmot-exec(1)*](./marmot-exec.1.md),

--- a/man/markdown/marmot.7.md
+++ b/man/markdown/marmot.7.md
@@ -2,16 +2,14 @@
 author:
 - Kyle Krull
 date: May 2024
-title: 'MARMOT(7) Version 0.6.1 \| Meta Repo Management Tool'
+title: MARMOT(7) Version 0.6.1 \| Meta Repo Management Tool
 ---
 
-NAME
-====
+# NAME
 
 **marmot** - Meta Repo Management Tool
 
-DESCRIPTION
-===========
+# DESCRIPTION
 
 **marmot** creates and maintains a Meta Repository (e.g. a "Meta Repo")
 of several Git repositories.
@@ -21,8 +19,7 @@ other Git repositories that are grouped into 1 or more categories.
 **marmot** helps you work with all the repositories in a category, as if
 they are a single unit.
 
-What it Does
-------------
+## What it Does
 
 **marmot** creates a directory structure in the meta repo's file system
 to mirror the way that repositories have been categorized, so that there
@@ -38,15 +35,13 @@ indirectly by passing a shell command and the name of the category to
 a category, instead of getting distracted by irrelevant sources in
 unrelated repositories.
 
-GETTING STARTED
-===============
+# GETTING STARTED
 
-Initialize a Meta Repo
-----------------------
+## Initialize a Meta Repo
 
 Before using **marmot**, you will need to:
 
-``` {.sh}
+``` sh
 $ marmot init
 Initialized meta repository at ~/meta/.marmot
 ```
@@ -54,13 +49,12 @@ Initialized meta repository at ~/meta/.marmot
 Now you have a Meta Repo, but it will not be very useful until you
 register some Git repositories and categorize them in some way.
 
-Register Repositories
----------------------
+## Register Repositories
 
 Let us assume that you have cloned some Git repositories and put them in
 `$HOME/git`. Note however that they can be on any reachable path.
 
-``` {.sh}
+``` sh
 marmot repo register ~/git/app-ui ~/git/app-server ~/git/app-database
 ```
 
@@ -71,8 +65,7 @@ every registered repository with **marmot exec**.
 This is useful for a small number of repositories, but categorizing them
 allows for finer-grained control.
 
-Categorize Repositories
------------------------
+## Categorize Repositories
 
 Categorizing Git repositories in **marmot** allows you to work on
 subsets of all the Git repositories you have on your machine. Each Git
@@ -84,7 +77,7 @@ the way you use them are up to you.
 
 Creating a new category creates a directory structure in the Meta Repo:
 
-``` {.sh}
+``` sh
 $ marmot category create project frontend services
 + ~/meta/project (category)
 + ~/meta/project/frontend (sub-category)
@@ -94,14 +87,14 @@ $ marmot category create project frontend services
 Adding a repository to a category creates a symlink to it, in the Meta
 Repo:
 
-``` {.sh}
+``` sh
 # Group together front-end components for the same project
 $ marmot category add project/frontend ~/git/webclient ~/git/webconfig
 + project/frontend/webclient (link)
 + project/frontend/webconfig (link)
 ```
 
-``` {.sh}
+``` sh
 # Group together back-end components for the same project
 $ marmot category add project/services ~/git/fooservice ~/git/barservice
 + project/services/fooservice (link)
@@ -111,67 +104,62 @@ $ marmot category add project/services ~/git/fooservice ~/git/barservice
 In the above example, both microservices are now grouped together in
 `~/meta/project/services`:
 
-``` {.sh}
+``` sh
 $ ls -l ~/meta/project/services
 lrwxr-xr-x somebody  users  ... barservice -> ~/git/barservice
 lrwxr-xr-x somebody  users  ... fooservice -> ~/git/fooservice
 ```
 
-EXAMPLE
-=======
+# EXAMPLE
 
 Note that examples list directories using `~/` instead of the path to an
 imaginary home directory, for brevity.
 
-Use Categories for Editing
---------------------------
+## Use Categories for Editing
 
 Sometimes it can be helpful to have all the code that is
 strongly-related by a common reason to change open in a single editor.
 Imagine how opening repositories for a front-end app and its feature
 flags in a single editor might help you spot typos and stale flags:
 
-``` {.sh}
+``` sh
 # Create a workspace to commit to multiple Git repos at the same time
 code ~/meta/project/frontend/*
 ```
 
-Use Categories for Shell Commands
----------------------------------
+## Use Categories for Shell Commands
 
 Sometimes it can be helpful to run the a shell command on several--but
 not all--repositories at once. Imagine how categorizing repositories by
 platform might make it easier to check if they are all using the same
 version of the platform:
 
-``` {.sh}
+``` sh
 $ marmot exec --category platform/node cat .node-version
 ~/meta/platform/node/fooclient: v16.0
 ~/meta/platform/node/barclient: v18.0
 ```
 
-Search Within a Category
-------------------------
+## Search Within a Category
 
 Sometimes it can be helpful to search for the same text in several
 places.
 
-``` {.sh}
+``` sh
 # Are all API clients using the same version?
 $ marmot exec --category api/client git grep 'apiVersion'
 ~/meta/api/client/fooclient/api.js: apiVersion: "1.0"
 ~/meta/api/client/barclient/api.js: apiVersion: "2.0"
 ```
 
-``` {.sh}
+``` sh
 # Are both sides of an API using the same names for things?
 $ marmot exec --category webapp git grep -e 'some[_]?field'
 ~/meta/webapp/fooserver/controller.js: some_field: "42"
 ~/meta/webapp/barclient/api.js: const answer = response.someField
 ```
 
-SEE ALSO
-========
+# SEE ALSO
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-category(1)*](./marmot-category.1.md),

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ source-debug:
 	$(info Sources:)
 	$(info - srcdir: $(srcdir))
 
-## Standard Targets
+#. STANDARD TARGETS
 
 .PHONY: all clean install test uninstall
 all:
@@ -47,19 +47,27 @@ all:
 clean:
 	@:
 
-install:
+install: #> Install symlink from $(bindir) to sources
 	mkdir -p $(bindir)
 	ln -f -s $(srcdir)/marmot.zsh $(bindir)/marmot
 
 test:
 	@:
 
-uninstall:
+uninstall: #> Delete symlink from $(bindir)
 	$(RM) $(bindir)/marmot
 
-## Other Targets
+#. OTHER TARGETS
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug source-debug
+debug: path-debug source-debug #> Show debugging information
 	@:
+
+.PHONY: help
+help: #> Show this help
+	@sed -n \
+		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/:.*#> /:/p' \
+		$(MAKEFILE_LIST) \
+		| column -ts :


### PR DESCRIPTION
# Changes

## Primary change


## Supporting changes

- Rebuild Markdown manual.  For some reason, the versions of Pandoc on
  Debian/MacOS are producing different - but equivalent - formats.
- Update `man/Makefile` `all` task to build the markdown manual.
- Add `help` target to makefiles, so they are self-documenting.  Port content from markdown documentation.

## Future work


## Version

Same.
