### PR TITLE
Consistent Markdown Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Start with the basics:
 
 Then learn more:
 
-- [Command Reference](./man/markdown/marmot.1.md): (_Or run `make -C man install` followed by `man
+- [Command Reference](./man/markdown/marmot.1.md) (_Or run `make all install` followed by `man
   marmot`_)
 - [Why does Marmot exist?](./doc/why.md)
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -154,5 +154,4 @@ $(markdown_manual_objects_dir):
 	mkdir -p markdown
 
 markdown/%.md: pandoc/%.md
-	$(PANDOC) "$<" $(PANDOCFLAGS) -o "$@" -s \
-		-t markdown-definition_lists-line_blocks
+	$(PANDOC) $< $(PANDOCFLAGS) -o $@ --atx-headers -s -t gfm

--- a/man/Makefile
+++ b/man/Makefile
@@ -154,4 +154,4 @@ $(markdown_manual_objects_dir):
 	mkdir -p markdown
 
 markdown/%.md: pandoc/%.md
-	$(PANDOC) $< $(PANDOCFLAGS) -o $@ --atx-headers -s -t gfm
+	$(PANDOC) $< $(PANDOCFLAGS) -o $@ -s -t gfm

--- a/man/markdown/marmot-category-add.1.md
+++ b/man/markdown/marmot-category-add.1.md
@@ -1,19 +1,12 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-CATEGORY-ADD(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot category add** - Add repositories to a category
 
 # SYNOPSIS
 
-**marmot category add** \[**\--help**\]\
-**marmot category add** *category* *repository* \[...\]\
-**marmot category add** *category*/*sub-category* *repository* \[...\]
+**marmot category add** \[**--help**\]  
+**marmot category add** *category* *repository* \[…\]  
+**marmot category add** *category*/*sub-category* *repository* \[…\]
 
 # DESCRIPTION
 
@@ -23,8 +16,8 @@ work within a sub-category.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -36,21 +29,21 @@ See [*marmot-category(1)*](./marmot-category.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # EXAMPLE
 
-Add a repository to the "user" category:
+Add a repository to the “user” category:
 
 ``` sh
 marmot category add user ~/git/dotfiles
 ```
 
-Add some repositories to the "wily" project (lookout Dr. Light):
+Add some repositories to the “wily” project (lookout Dr. Light):
 
 ``` sh
 marmot category add project/wily ~/git/robot-masters ~/git/skull-fortress

--- a/man/markdown/marmot-category-create.1.md
+++ b/man/markdown/marmot-category-create.1.md
@@ -1,19 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-CATEGORY-CREATE(1) Version 0.6.1 \| Meta Repo Management
-  Tool
----
-
 # NAME
 
 **marmot category create** - Create a category
 
 # SYNOPSIS
 
-**marmot category create** \[**\--help**\]\
-**marmot category create** *category* \[*sub-category* ...\]
+**marmot category create** \[**--help**\]  
+**marmot category create** *category* \[*sub-category* …\]
 
 # DESCRIPTION
 
@@ -22,8 +14,8 @@ title: MARMOT-CATEGORY-CREATE(1) Version 0.6.1 \| Meta Repo Management
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -35,29 +27,29 @@ See [*marmot-category(1)*](./marmot-category.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # EXAMPLE
 
-Create a "lang" category with sub-categories "java" and "typescript":
+Create a “lang” category with sub-categories “java” and “typescript”:
 
 ``` sh
 marmot category create lang java typescript
 ```
 
-Create a "platform" category with sub-categories "beam,"clr", "jvm", and
-"node":
+Create a “platform” category with sub-categories “beam,”clr“,”jvm“,
+and”node":
 
 ``` sh
 marmot category create platform beam clr jvm node
 ```
 
-Create a "project" category with sub-categories "dotnet-8-migration" and
-"skunkworks":
+Create a “project” category with sub-categories “dotnet-8-migration” and
+“skunkworks”:
 
 ``` sh
 marmot category create project dotnet-8-migration skunkworks

--- a/man/markdown/marmot-category-list.1.md
+++ b/man/markdown/marmot-category-list.1.md
@@ -1,18 +1,10 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-CATEGORY-LIST(1) Version 0.6.1 \| Meta Repo Management
-  Tool
----
-
 # NAME
 
 **marmot category list** - List categories
 
 # SYNOPSIS
 
-**marmot category list** \[**\--help**\]\
+**marmot category list** \[**--help**\]  
 **marmot category list**
 
 # DESCRIPTION
@@ -22,8 +14,8 @@ repositories.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -35,11 +27,11 @@ See [*marmot-category(1)*](./marmot-category.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # SEE ALSO
 

--- a/man/markdown/marmot-category-rm.1.md
+++ b/man/markdown/marmot-category-rm.1.md
@@ -1,19 +1,12 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-CATEGORY-RM(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot category rm** - Remove repositories from a category
 
 # SYNOPSIS
 
-**marmot category rm** \[**\--help**\]\
-**marmot category rm** *category* *repository* \[...\]\
-**marmot category rm** *category*/*sub-category* *repository* \[...\]
+**marmot category rm** \[**--help**\]  
+**marmot category rm** *category* *repository* \[…\]  
+**marmot category rm** *category*/*sub-category* *repository* \[…\]
 
 # DESCRIPTION
 
@@ -23,8 +16,8 @@ work within a sub-category.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -36,15 +29,15 @@ See [*marmot-category(1)*](./marmot-category.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # EXAMPLE
 
-Remove a newly-categorized repository from the "inbox" category:
+Remove a newly-categorized repository from the “inbox” category:
 
 ``` sh
 marmot category add lang/shiny ~/git/what-is-this

--- a/man/markdown/marmot-category.1.md
+++ b/man/markdown/marmot-category.1.md
@@ -1,18 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-CATEGORY(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot category** - Work with categories
 
 # SYNOPSIS
 
-**marmot category** \[**\--help**\]\
-**marmot category** *sub-command* \[*args* ...\]
+**marmot category** \[**--help**\]  
+**marmot category** *sub-command* \[*args* …\]
 
 # DESCRIPTION
 
@@ -21,40 +14,40 @@ something with categories.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # SUB-COMMANDS
 
-[**add**](./marmot-category-add.1.md)  
-Add repositories to a category
+  - [**add**](./marmot-category-add.1.md)  
+    Add repositories to a category
 
-[**create**](./marmot-category-create.1.md)  
-Create a new category
+  - [**create**](./marmot-category-create.1.md)  
+    Create a new category
 
-[**list**](./marmot-category-list.1.md)  
-List categories
+  - [**list**](./marmot-category-list.1.md)  
+    List categories
 
-[**rm**](./marmot-category-rm.1.md)  
-Remove repositories from a category
+  - [**rm**](./marmot-category-rm.1.md)  
+    Remove repositories from a category
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path to the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path to the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Each category and references to their repositories
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Each category and references to their repositories
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command
+  - 1+  
+    Invalid command
 
 # SEE ALSO
 

--- a/man/markdown/marmot-category.1.md
+++ b/man/markdown/marmot-category.1.md
@@ -55,6 +55,6 @@ something with categories.
 [*marmot-category-add(1)*](./marmot-category-add.1.md),
 [*marmot-category-create(1)*](./marmot-category-create.1.md),
 [*marmot-category-list(1)*](./marmot-category-list.1.md),
-[*marmot-category-rm*](./marmot-category-rm.1.md)
+[*marmot-category-rm(1)*](./marmot-category-rm.1.md)
 
 [*marmot(7)*](./marmot.7.md)

--- a/man/markdown/marmot-exec.1.md
+++ b/man/markdown/marmot-exec.1.md
@@ -1,20 +1,13 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-EXEC(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot exec** - Execute a command in multiple repositories
 
 # SYNOPSIS
 
-**marmot exec** \[**\--help**\]\
-**marmot exec** \[**\--category** *category*\|*sub-category*\]
-\[**\--direnv**\] \[**\--repo-names** **heading**\|**inline**\]
-*shell-command* \[*args* ...\]
+**marmot exec** \[**--help**\]  
+**marmot exec** \[**--category** *category*|*sub-category*\]
+\[**--direnv**\] \[**--repo-names** **heading**|**inline**\]
+*shell-command* \[*args* …\]
 
 # DESCRIPTION
 
@@ -25,40 +18,40 @@ repositories, or those matching a given *category* or *sub-category*.
 **marmot exec** changes directories to each repository before running
 *shell-command*, to ensure that any path-specific environment settings
 are applied. This is helpful for directory-based tools such as `direnv`,
-`fnm`, and `rvm`, which update the shell's path and other parts of its
+`fnm`, and `rvm`, which update the shell’s path and other parts of its
 environment when changing directories. The usefulness of the shell
 command may depend upon it, for example when checking if all
 repositories in a project use the same version of Node.js.
 
 # OPTIONS
 
-**\--direnv**  
-Suppress `direnv` output when changing directories
+  - **--direnv**  
+    Suppress `direnv` output when changing directories
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
-**\--repo-names**  
-Print repository names **inline** prior to output from *shell-command*,
-or as a **heading** above it
+  - **--repo-names**  
+    Print repository names **inline** prior to output from
+    *shell-command*, or as a **heading** above it
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path to the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path to the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Categories and registered repositories
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Categories and registered repositories
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or **shell-command** failure
+  - 1+  
+    Invalid command or **shell-command** failure
 
 # NOTES
 
@@ -108,14 +101,14 @@ marmot exec --category project/too-many-microservices \
   git branch --show-current
 ```
 
-Git: Pull all the things!
+Git: Pull all the things\!
 
 ``` sh
 marmot exec --repo-names heading \
   git pull --ff-only origin
 ```
 
-Git: Push all the things!
+Git: Push all the things\!
 
 ``` sh
 marmot exec --repo-names heading \

--- a/man/markdown/marmot-init.1.md
+++ b/man/markdown/marmot-init.1.md
@@ -1,17 +1,10 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-INIT(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot init** - Initialize a meta repo
 
 # SYNOPSIS
 
-**marmot init** \[**\--help**\]\
+**marmot init** \[**--help**\]  
 **marmot init**
 
 # DESCRIPTION
@@ -21,26 +14,26 @@ already present.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path in which to create the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path in which to create the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Blank metadata with no registered repositories or categories
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Blank metadata with no registered repositories or categories
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command, command failure, or meta repo already exists
+  - 1+  
+    Invalid command, command failure, or meta repo already exists
 
 # SEE ALSO
 

--- a/man/markdown/marmot-meta-home.1.md
+++ b/man/markdown/marmot-meta-home.1.md
@@ -1,17 +1,10 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-META-HOME(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot meta home** - Show path to Meta Repo
 
 # SYNOPSIS
 
-**marmot meta home** \[**\--help**\]\
+**marmot meta home** \[**--help**\]  
 **marmot meta home**
 
 # DESCRIPTION
@@ -20,8 +13,8 @@ title: MARMOT-META-HOME(1) Version 0.6.1 \| Meta Repo Management Tool
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -33,11 +26,11 @@ See [*marmot-meta(1)*](./marmot-meta.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # SEE ALSO
 

--- a/man/markdown/marmot-meta.1.md
+++ b/man/markdown/marmot-meta.1.md
@@ -1,18 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-META(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot meta** - Information about the meta repo
 
 # SYNOPSIS
 
-**marmot meta** \[**\--help**\]\
-**marmot meta** *sub-command* \[*args* ...\]
+**marmot meta** \[**--help**\]  
+**marmot meta** *sub-command* \[*args* …\]
 
 # DESCRIPTION
 
@@ -21,31 +14,31 @@ something on the Meta Repo.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # SUB-COMMANDS
 
-[**home**](./marmot-meta-home.1.md)  
-Show the base directory of the Meta Repo
+  - [**home**](./marmot-meta-home.1.md)  
+    Show the base directory of the Meta Repo
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path to the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path to the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Each category and references to their repositories
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Each category and references to their repositories
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command
+  - 1+  
+    Invalid command
 
 # SEE ALSO
 

--- a/man/markdown/marmot-repo-list.1.md
+++ b/man/markdown/marmot-repo-list.1.md
@@ -1,18 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-REPO-LIST(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot repo list** - List repositories
 
 # SYNOPSIS
 
-**marmot repo list** \[**\--help**\]\
-**marmot repo list** \[**\--category** *category*\|*sub-category*\]
+**marmot repo list** \[**--help**\]  
+**marmot repo list** \[**--category** *category*|*sub-category*\]
 
 # DESCRIPTION
 
@@ -22,12 +15,12 @@ given criteria.
 
 # OPTIONS
 
-**\--category**  
-List repositories that have been added to the given *category* or
-*sub-category*
+  - **--category**  
+    List repositories that have been added to the given *category* or
+    *sub-category*
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -39,11 +32,11 @@ See [*marmot-repo(1)*](./marmot-repo.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # EXAMPLE
 

--- a/man/markdown/marmot-repo-prune.1.md
+++ b/man/markdown/marmot-repo-prune.1.md
@@ -1,17 +1,10 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-REPO-PRUNE(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot repo prune** - Prune references to missing repositories
 
 # SYNOPSIS
 
-**marmot repo prune** \[**\--help**\]\
+**marmot repo prune** \[**--help**\]  
 **marmot repo prune**
 
 # DESCRIPTION
@@ -25,8 +18,8 @@ categories that included it.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -38,11 +31,11 @@ See [*marmot-repo(1)*](./marmot-repo.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # SEE ALSO
 

--- a/man/markdown/marmot-repo-register.1.md
+++ b/man/markdown/marmot-repo-register.1.md
@@ -1,19 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-REPO-REGISTER(1) Version 0.6.1 \| Meta Repo Management
-  Tool
----
-
 # NAME
 
 **marmot repo register** - Register repositories to manage
 
 # SYNOPSIS
 
-**marmot repo register** \[**\--help**\]\
-**marmot repo register** *repository-path* \[...\]
+**marmot repo register** \[**--help**\]  
+**marmot repo register** *repository-path* \[…\]
 
 # DESCRIPTION
 
@@ -27,8 +19,8 @@ the process of finding and registering lots of Git repositories at once.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # ENVIRONMENT VARIABLES
 
@@ -40,15 +32,15 @@ See [*marmot-repo(1)*](./marmot-repo.1.md).
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # EXAMPLE
 
-Register all the things!
+Register all the things\!
 
 ``` sh
 find ~/git -type d -name .git \

--- a/man/markdown/marmot-repo.1.md
+++ b/man/markdown/marmot-repo.1.md
@@ -50,6 +50,7 @@ something with repositories.
 
 [*marmot(1)*](./marmot.1.md),
 [*marmot-repo-list(1)*](./marmot-repo-list.1.md),
+[*marmot-repo-prune(1)*](./marmot-repo-prune.1.md),
 [*marmot-repo-register(1)*](./marmot-repo-register.1.md)
 
 [*marmot(7)*](./marmot.7.md)

--- a/man/markdown/marmot-repo.1.md
+++ b/man/markdown/marmot-repo.1.md
@@ -1,18 +1,11 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT-REPO(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot repo** - Work with repositories
 
 # SYNOPSIS
 
-**marmot repo** \[**\--help**\]\
-**marmot repo** *sub-command* \[*args* ...\]
+**marmot repo** \[**--help**\]  
+**marmot repo** *sub-command* \[*args* …\]
 
 # DESCRIPTION
 
@@ -21,37 +14,37 @@ something with repositories.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
 # SUB-COMMANDS
 
-[**list**](./marmot-repo-list.1.md)  
-List repositories
+  - [**list**](./marmot-repo-list.1.md)  
+    List repositories
 
-[**prune**](./marmot-repo-prune.1.md)  
-Prune references to missing repositories
+  - [**prune**](./marmot-repo-prune.1.md)  
+    Prune references to missing repositories
 
-[**register**](./marmot-repo-register.1.md)  
-Register repositories to manage
+  - [**register**](./marmot-repo-register.1.md)  
+    Register repositories to manage
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path to the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path to the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Repositories that **marmot** knows about
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Repositories that **marmot** knows about
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command
+  - 1+  
+    Invalid command
 
 # SEE ALSO
 

--- a/man/markdown/marmot.1.md
+++ b/man/markdown/marmot.1.md
@@ -1,10 +1,3 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT(1) Version 0.6.1 \| Meta Repo Management Tool
----
-
 <!---
 man-pages reference: https://linux.die.net/man/7/man-pages
 -->
@@ -15,8 +8,8 @@ man-pages reference: https://linux.die.net/man/7/man-pages
 
 # SYNOPSIS
 
-**marmot** \[**\--help**\] \[**\--version**\]\
-**marmot** *command* \[*args* ...\]
+**marmot** \[**--help**\] \[**--version**\]  
+**marmot** *command* \[*args* …\]
 
 # DESCRIPTION
 
@@ -31,52 +24,52 @@ they are a single unit. See [*marmot(7)*](./marmot.7.md) to get started.
 
 # OPTIONS
 
-**\--help**  
-Show help
+  - **--help**  
+    Show help
 
-**\--version**  
-Prints the **marmot** suite version that the program came from
+  - **--version**  
+    Prints the **marmot** suite version that the program came from
 
 # COMMANDS
 
 ## Meta Repo Commands
 
-[**init**](./marmot-init.1.md)  
-Create a new meta repo
+  - [**init**](./marmot-init.1.md)  
+    Create a new meta repo
 
-[**meta**](./marmot-meta.1.md)  
-Information about the meta repo itself
+  - [**meta**](./marmot-meta.1.md)  
+    Information about the meta repo itself
 
 ## Category commands
 
-[**category**](./marmot-category.1.md)  
-Work with categories
+  - [**category**](./marmot-category.1.md)  
+    Work with categories
 
 ## Repository Commands
 
-[**exec**](./marmot-exec.1.md)  
-Execute a shell command in multiple repositories
+  - [**exec**](./marmot-exec.1.md)  
+    Execute a shell command in multiple repositories
 
-[**repo**](./marmot-repo.1.md)  
-Work with repositories
+  - [**repo**](./marmot-repo.1.md)  
+    Work with repositories
 
 # ENVIRONMENT VARIABLES
 
-**MARMOT_META_REPO**  
-Path to the Meta Repo (default: \$HOME/meta)
+  - **MARMOT\_META\_REPO**  
+    Path to the Meta Repo (default: $HOME/meta)
 
 # FILES
 
-*\$MARMOT_META_REPO/.marmot/meta-repo.json*  
-Registered repositories and how they relate to one another
+  - *$MARMOT\_META\_REPO/.marmot/meta-repo.json*  
+    Registered repositories and how they relate to one another
 
 # EXIT STATUS
 
-0  
-Success
+  - 0  
+    Success
 
-1+  
-Invalid command or command failure
+  - 1+  
+    Invalid command or command failure
 
 # SEE ALSO
 

--- a/man/markdown/marmot.7.md
+++ b/man/markdown/marmot.7.md
@@ -1,17 +1,10 @@
----
-author:
-- Kyle Krull
-date: May 2024
-title: MARMOT(7) Version 0.6.1 \| Meta Repo Management Tool
----
-
 # NAME
 
 **marmot** - Meta Repo Management Tool
 
 # DESCRIPTION
 
-**marmot** creates and maintains a Meta Repository (e.g. a "Meta Repo")
+**marmot** creates and maintains a Meta Repository (e.g. a “Meta Repo”)
 of several Git repositories.
 
 A Meta Repo, for the purposes of this program, is a set of references to
@@ -21,7 +14,7 @@ they are a single unit.
 
 ## What it Does
 
-**marmot** creates a directory structure in the meta repo's file system
+**marmot** creates a directory structure in the meta repo’s file system
 to mirror the way that repositories have been categorized, so that there
 is a `/:category/:sub-category` directory for each (sub-)category. Each
 directory contains symbolic links back to the Git repositories that are
@@ -29,7 +22,7 @@ grouped into the same (sub-)category.
 
 Users run commands from one of these directories in order to restrict
 commands to the Git repositories that have that category in common. This
-can be done directly by passing a category's path to a shell command or
+can be done directly by passing a category’s path to a shell command or
 indirectly by passing a shell command and the name of the category to
 **marmot exec**. Either way causes a command to run within the scope of
 a category, instead of getting distracted by irrelevant sources in
@@ -129,8 +122,8 @@ code ~/meta/project/frontend/*
 
 ## Use Categories for Shell Commands
 
-Sometimes it can be helpful to run the a shell command on several--but
-not all--repositories at once. Imagine how categorizing repositories by
+Sometimes it can be helpful to run the a shell command on several–but
+not all–repositories at once. Imagine how categorizing repositories by
 platform might make it easier to check if they are all using the same
 version of the platform:
 

--- a/man/pandoc/marmot-category.1.md
+++ b/man/pandoc/marmot-category.1.md
@@ -66,6 +66,6 @@
 [*marmot(1)*](./marmot.1.md), [*marmot-category-add(1)*](./marmot-category-add.1.md),
 [*marmot-category-create(1)*](./marmot-category-create.1.md),
 [*marmot-category-list(1)*](./marmot-category-list.1.md),
-[*marmot-category-rm*](./marmot-category-rm.1.md)
+[*marmot-category-rm(1)*](./marmot-category-rm.1.md)
 
 [*marmot(7)*](./marmot.7.md)

--- a/man/pandoc/marmot-repo.1.md
+++ b/man/pandoc/marmot-repo.1.md
@@ -60,6 +60,7 @@
 # SEE ALSO
 
 [*marmot(1)*](./marmot.1.md), [*marmot-repo-list(1)*](./marmot-repo-list.1.md),
+[*marmot-repo-prune(1)*](./marmot-repo-prune.1.md),
 [*marmot-repo-register(1)*](./marmot-repo-register.1.md)
 
 [*marmot(7)*](./marmot.7.md)


### PR DESCRIPTION
# Changes

## Primary change

Build the Markdown manual with consistent formatting, when running `pandoc` from MacOS and Linux.

## Supporting changes

- Add a missing link and fix a mis-named one in See Also

## Future work


## Version

Same
