### PR TITLE
Update remote register to read from standard input

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -2,7 +2,15 @@ $schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell
 dictionaries: []
 dictionaryDefinitions: []
 enableFiletypes:
+  - github-actions-workflow
   - go
+  - json
+  - makefile
+  - markdown
+  - plaintext
+  - shellscript
+  - text
+  - yaml
 ignorePaths:
   - .gitignore
   - cspell.config.yaml
@@ -10,5 +18,7 @@ ignoreWords: []
 import: []
 version: "0.2"
 words:
+  - fswatch
   - kkrull
   - Krull
+  - Pandoc

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -18,7 +18,11 @@ ignoreWords: []
 import: []
 version: "0.2"
 words:
+  - cmdremote
+  - cmdroot
   - fswatch
   - kkrull
   - Krull
   - Pandoc
+  - pflag
+  - svcfs

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,14 @@
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+dictionaries: []
+dictionaryDefinitions: []
+enableFiletypes:
+  - go
+ignorePaths:
+  - .gitignore
+  - cspell.config.yaml
+ignoreWords: []
+import: []
+version: "0.2"
+words:
+  - kkrull
+  - Krull

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -2,6 +2,14 @@
 
 Tools used by some part of this project's build, deployment, or development processes.
 
+## Code Spell Checker
+
+<https://cspell.org/>
+
+### Files
+
+- `cspell.config.yaml`: Configuration and dictionary
+
 ## EditorConfig
 
 <https://editorconfig.org/>

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -10,6 +10,19 @@ Tools used by some part of this project's build, deployment, or development proc
 
 - `cspell.config.yaml`: Configuration and dictionary
 
+### Documentation
+
+- Configuration file:
+  - `enableFiletypes`:
+    <https://streetsidesoftware.com/vscode-spell-checker/docs/configuration/#cspellenabledfiletypes>
+
+### Interactions
+
+- VS Code extension:
+  <https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker>
+
+---
+
 ## EditorConfig
 
 <https://editorconfig.org/>
@@ -21,6 +34,9 @@ Tools used by some part of this project's build, deployment, or development proc
 ### Interactions
 
 - [`pre-commit`](#pre-commit) includes hooks to ensure files comply with EditorConfig
+- VS Code extension: <https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig>
+
+---
 
 ## `fswatch`
 
@@ -29,6 +45,8 @@ Tools used by some part of this project's build, deployment, or development proc
 ### Interactions
 
 - [GNU Make](#gnu-make) includes tasks that use `fswatch`
+
+---
 
 ## GitHub Actions
 
@@ -42,11 +60,15 @@ Tools used by some part of this project's build, deployment, or development proc
 
 ### Files
 
-- `.github/workflows/`: Job definitions.
+- `.github/workflows/`: Job definitions
 
 ### Interactions
 
 - [`pre-commit`](#pre-commit) checks are also run during some jobs
+- VS Code extension:
+  <https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions>
+
+---
 
 ## GNU Make
 
@@ -62,7 +84,31 @@ Tools used by some part of this project's build, deployment, or development proc
 
 - `Makefile`: targets to build everything and tasks to help set up your environment
 - `man/Makefile`: targets to build manuals
+- `src/go/Makefile`: targets to build the Go version of marmot
 - `src/zsh/Makefile`: targets to build programs with scripts
+
+### Interactions
+
+- VS Code extension: <https://marketplace.visualstudio.com/items?itemName=ms-vscode.makefile-tools>
+
+---
+
+## Go
+
+<https://go.dev/>
+
+### Documentation
+
+- A Tour of Go: <https://go.dev/tour/>
+- Effective Go: <https://go.dev/doc/effective_go>
+- Package and documentation index: <https://pkg.go.dev/>
+
+### Interactions
+
+- [GNU Make](#gnu-make) builds binaries from Go sources and automates other common development tasks
+- VS Code extension: <https://marketplace.visualstudio.com/items?itemName=golang.Go>
+
+---
 
 ## Homebrew
 
@@ -77,9 +123,11 @@ Tools used by some part of this project's build, deployment, or development proc
 In `etc/macos/`:
 
 - `Brewfile.developer` and `Brewfile.developer.lock.json`: packages for developers, to work on this
-  project.
+  project
 - `Brewfile.user` and `Brewfile.user.lock.json`: packages for end users, to run the programs built
-  from these sources.
+  from these sources
+
+---
 
 ## `jo`
 
@@ -90,6 +138,8 @@ In `etc/macos/`:
 - GitHub: <https://github.com/jpmens/jo>
 - Installation: <https://github.com/jpmens/jo?tab=readme-ov-file#install>
 
+---
+
 ## `jq`
 
 <https://jqlang.github.io/jq/>
@@ -98,7 +148,26 @@ In `etc/macos/`:
 
 - Manual: <https://jqlang.github.io/jq/manual/v1.7/>
 
-## `markdownlint-cli2`
+---
+
+## Markdown
+
+<https://www.markdownguide.org/>
+
+### Documentation
+
+- Syntax: <https://www.markdownguide.org/basic-syntax/>
+
+### Interactions
+
+- [Mermaid](#mermaid) is embedded in some Markdown documents
+- VS Code extensions
+  - Markdown All in One:
+    <https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one>
+
+---
+
+## Markdownlint
 
 <https://github.com/DavidAnson/markdownlint-cli2>
 
@@ -106,6 +175,8 @@ In `etc/macos/`:
 
 - Configuration JSON schema:
   <https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2jsonc>
+- Main: <https://github.com/DavidAnson/markdownlint>
+- Rules: <https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md>
 - `pre-commit` hook: <https://github.com/DavidAnson/markdownlint-cli2?tab=readme-ov-file#pre-commit>
 
 ### Files
@@ -115,6 +186,27 @@ In `etc/macos/`:
 ### Interactions
 
 - [`pre-commit`](#pre-commit) includes hooks to ensure files comply with linting rules
+- VS Code extension:
+  <https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint>
+
+---
+
+## Mermaid
+
+<https://mermaid-js.github.io/mermaid>
+
+### Documentation
+
+- Customized styling directives: <https://stackoverflow.com/q/71864287/112682>
+- Syntax: <https://mermaid.js.org/intro/n00b-syntaxReference.html>
+
+### Interactions
+
+- VS Code extensions
+  - Markdown Preview Mermaid Support:
+    <https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid>
+  - Mermaid Editor:
+    <https://marketplace.visualstudio.com/items?itemName=tomoyukim.vscode-mermaid-editor>
 
 ## Pandoc
 
@@ -128,6 +220,8 @@ In `etc/macos/`:
 ### Interactions
 
 - [GNU Make](#gnu-make) runs Pandoc to convert command documentation to manuals
+
+---
 
 ## `pre-commit`
 
@@ -150,8 +244,10 @@ In `etc/macos/`:
 - [EditorConfig](#editorconfig) is checked by `pre-commit`
 - [GNU Make](#gnu-make) contains [tasks](./task-automation.md#pre-commit-targets) to install Git
   hooks and update `pre-commit` repositories
-- [`markdownlint-cli2`](#markdownlint-cli2) is run by `pre-commit`
+- [`markdownlint-cli2`](#markdownlint) is run by `pre-commit`
 - [ShellCheck](#shellcheck) is run by `pre-commit`
+
+---
 
 ## ShellCheck
 
@@ -170,6 +266,8 @@ In `etc/macos/`:
 ### Interactions
 
 - [`pre-commit`](#pre-commit) includes hooks to ensure files comply with ShellCheck
+
+---
 
 ## Z Shell
 

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -13,8 +13,7 @@ func NewRegisterCommand() *registerCommand {
 	return &registerCommand{}
 }
 
-// TODO KDK: This worked and produced https URLS: ./marmot remote register $(gh repo list --json url | jq -r '.[].url | @sh' | xargs)
-// TODO KDK: This did not work, because it lacks a scheme: ./marmot remote register $(gh repo list --json sshUrl | jq -r '.[].sshUrl | @sh' | xargs)
+// TODO KDK: Read from stdin/pipe: gh repo list --json url | jq -r '.[].url' | ./marmot remote register
 type registerCommand struct{}
 
 func (registerCommand) ToCobraCommand() *cobra.Command {

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -13,18 +13,20 @@ func NewRegisterCommand() *registerCommand {
 	return &registerCommand{}
 }
 
-// TODO KDK: Read from stdin/pipe: gh repo list --json url | jq -r '.[].url' | ./marmot remote register
+// TODO KDK: Read from stdin/pipe
 type registerCommand struct{}
 
 func (registerCommand) ToCobraCommand() *cobra.Command {
 	return &cobra.Command{
-		Args: cobra.MinimumNArgs(1),
+		Args:                  cobra.MinimumNArgs(1),
+		DisableFlagsInUseLine: true,
 		Example: `marmot remote register https://github.com/drwily/skull-fortress
 gh repo list --json url | jq -r '.[].url' | marmot remote register -`,
-		Long:  "Register Git repositories on remote hosts with Marmot.",
+		Long: `Register Git repositories on remote hosts at each [URL].
+When URL is -, stop processing arguments and read newline-delimited URLs from standard input.`,
 		RunE:  runRegister,
 		Short: "Register remote repositories",
-		Use:   "register URL...",
+		Use:   "register [flags] [URL]... [-]",
 	}
 }
 

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -18,12 +18,13 @@ type registerCommand struct{}
 
 func (registerCommand) ToCobraCommand() *cobra.Command {
 	return &cobra.Command{
-		Args:    cobra.MinimumNArgs(1),
-		Example: `marmot remote register ssh://git@github.com/drwily/skull-fortress`,
-		Long:    "Register Git repositories on remote hosts with Marmot.",
-		RunE:    runRegister,
-		Short:   "Register remote repositories",
-		Use:     "register URL...",
+		Args: cobra.MinimumNArgs(1),
+		Example: `marmot remote register https://github.com/drwily/skull-fortress
+gh repo list --json url | jq -r '.[].url' | marmot remote register -`,
+		Long:  "Register Git repositories on remote hosts with Marmot.",
+		RunE:  runRegister,
+		Short: "Register remote repositories",
+		Use:   "register URL...",
 	}
 }
 

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -13,6 +13,8 @@ func NewRegisterCommand() *registerCommand {
 	return &registerCommand{}
 }
 
+// TODO KDK: This worked and produced https URLS: ./marmot remote register $(gh repo list --json url | jq -r '.[].url | @sh' | xargs)
+// TODO KDK: This did not work, because it lacks a scheme: ./marmot remote register $(gh repo list --json sshUrl | jq -r '.[].sshUrl | @sh' | xargs)
 type registerCommand struct{}
 
 func (registerCommand) ToCobraCommand() *cobra.Command {

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -14,7 +14,6 @@ func NewRegisterCommand() *registerCommand {
 	return &registerCommand{}
 }
 
-// TODO KDK: Read from stdin/pipe
 type registerCommand struct{}
 
 func (registerCommand) ToCobraCommand() *cobra.Command {

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -24,6 +24,7 @@ type rootCliCommand struct {
 
 func (root rootCliCommand) ToCobraCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
+		Args:    cobra.NoArgs,
 		Long:    "marmot manages a Meta Repository that organizes content in other (Git) repositories.",
 		RunE:    runRoot,
 		Short:   "Meta Repo Management Tool",

--- a/src/go/cmd/root/app_config.go
+++ b/src/go/cmd/root/app_config.go
@@ -13,6 +13,8 @@ type AppConfig interface {
 	Args() []string
 	ArgsAsUrls() ([]*url.URL, error)
 	Debug() bool
+	InputLines() []string
+	InputLinesAsUrls() ([]*url.URL, error)
 	MetaRepoPath() string
 	PrintDebug(writer io.Writer)
 }

--- a/src/go/cmd/root/root_params.go
+++ b/src/go/cmd/root/root_params.go
@@ -1,9 +1,11 @@
 package cmdroot
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 
 	"github.com/kkrull/marmot/core"
 	"github.com/kkrull/marmot/svcfs"
@@ -43,6 +45,7 @@ func (parser rootParamParser) Parse(flags *pflag.FlagSet, args []string) (AppCon
 			args:         args,
 			debug:        debug,
 			flagSet:      flags,
+			inputLines:   make([]string, 0),
 			metaRepoPath: metaRepoPath,
 		}
 
@@ -56,13 +59,33 @@ func (parser rootParamParser) ParseR(flags *pflag.FlagSet, args []string, stdin 
 	} else if metaRepoPath, pathErr := metaRepoFlag.GetString(flags); pathErr != nil {
 		return nil, pathErr
 	} else {
+		argsBeforeDash := make([]string, 0)
+		for _, arg := range args {
+			if strings.TrimSpace(arg) == "-" {
+				break
+			} else {
+				argsBeforeDash = append(argsBeforeDash, arg)
+			}
+		}
+
+		inputLines := make([]string, 0)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			line := scanner.Text()
+			inputLines = append(inputLines, line)
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			return nil, scanErr
+		}
+
 		config := &rootParams{
 			appFactory: use.NewAppFactory().
 				WithMetaDataAdmin(svcfs.NewJsonMetaRepoAdmin(parser.version)).
 				WithRepositorySource(svcfs.NewJsonMetaRepo(metaRepoPath)),
-			args:         args,
+			args:         argsBeforeDash,
 			debug:        debug,
 			flagSet:      flags,
+			inputLines:   inputLines,
 			metaRepoPath: metaRepoPath,
 		}
 
@@ -76,17 +99,18 @@ type rootParams struct {
 	args         []string
 	debug        bool
 	flagSet      *pflag.FlagSet
+	inputLines   []string
 	metaRepoPath string
 }
 
 func (params rootParams) AppFactory() use.AppFactory { return params.appFactory }
-func (params rootParams) Args() []string             { return params.args }
 
+func (params rootParams) Args() []string { return params.args }
 func (params rootParams) ArgsAsUrls() ([]*url.URL, error) {
 	urls := make([]*url.URL, len(params.args))
 	for i, rawArg := range params.args {
 		if urlArg, parseErr := url.Parse(rawArg); parseErr != nil {
-			return nil, fmt.Errorf("url expected: %s; %w", rawArg, parseErr)
+			return nil, fmt.Errorf("url expected: <%s>; %w", rawArg, parseErr)
 		} else {
 			urls[i] = urlArg
 		}
@@ -95,14 +119,36 @@ func (params rootParams) ArgsAsUrls() ([]*url.URL, error) {
 	return urls, nil
 }
 
-func (params rootParams) Debug() bool          { return params.debug }
+func (params rootParams) Debug() bool { return params.debug }
+
+func (params rootParams) InputLines() []string { return params.inputLines }
+func (params rootParams) InputLinesAsUrls() ([]*url.URL, error) {
+	urls := make([]*url.URL, 0)
+	for _, rawLine := range params.inputLines {
+		trimmedLine := strings.TrimSpace(rawLine)
+		if trimmedLine == "" {
+			continue
+		} else if urlLine, parseErr := url.Parse(rawLine); parseErr != nil {
+			return nil, fmt.Errorf("url expected: <%s>; %w", rawLine, parseErr)
+		} else {
+			urls = append(urls, urlLine)
+		}
+	}
+
+	return urls, nil
+}
+
 func (params rootParams) MetaRepoPath() string { return params.metaRepoPath }
 func (params rootParams) PrintDebug(writer io.Writer) {
 	for i, arg := range params.args {
-		fmt.Fprintf(writer, "[%d]: %s\n", i, arg)
+		fmt.Fprintf(writer, "arg [%d]: %s\n", i, arg)
 	}
 
 	for _, flag := range rootFlags {
-		fmt.Fprintf(writer, "--%s=%s\n", flag.LongName(), flag.Find(params.flagSet))
+		fmt.Fprintf(writer, "flag --%s=%s\n", flag.LongName(), flag.Find(params.flagSet))
+	}
+
+	for i, line := range params.inputLines {
+		fmt.Fprintf(writer, "stdin [%d]: %s\n", i, line)
 	}
 }

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
 )
 
 require (
@@ -21,7 +22,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.4 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 )
 
 func NewJsonMetaRepoAdmin(version string) *JsonMetaRepoAdmin {
@@ -19,21 +20,19 @@ type JsonMetaRepoAdmin struct {
 /* MetaDataAdmin */
 
 func (admin *JsonMetaRepoAdmin) Create(repositoryDir string) error {
-	_, statErr := os.Stat(repositoryDir)
+	marmotDataDir := metaDataDir(repositoryDir)
+	_, statErr := os.Stat(marmotDataDir)
 	if errors.Is(statErr, fs.ErrNotExist) {
-		return initDirectory(
-			metaDataDir(repositoryDir),
-			metaDataFile(repositoryDir),
-			InitMetaRepoData(admin.version),
-		)
+		return initDirectory(metaDataFile(repositoryDir), InitMetaRepoData(admin.version))
 	} else if statErr != nil {
 		return fmt.Errorf("failed to check for existing meta repo %s; %w", repositoryDir, statErr)
 	} else {
-		return fmt.Errorf("path already exists: %s", repositoryDir)
+		return fmt.Errorf("path already exists: %s", marmotDataDir)
 	}
 }
 
-func initDirectory(metaDataDir string, metaDataFile string, rootObject *rootObjectData) error {
+func initDirectory(metaDataFile string, rootObject *rootObjectData) error {
+	metaDataDir := path.Dir(metaDataFile)
 	if dirErr := os.MkdirAll(metaDataDir, fs.ModePerm); dirErr != nil {
 		return fmt.Errorf("failed to make directory %s; %w", metaDataDir, dirErr)
 	} else if writeErr := rootObject.WriteTo(metaDataFile); writeErr != nil {

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -2,6 +2,7 @@ package svcfs_test
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -26,12 +27,20 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 	})
 
 	Describe("#Create", func() {
-		It("returns an error, given a path that already exists", func() {
-			Expect(os.Create(metaRepoPath)).NotTo(BeNil())
+		It("is cool with an existing path in which marmot has not been initialized", func() {
+			Expect(os.MkdirAll(metaRepoPath, fs.ModePerm)).To(Succeed())
+
+			subject = jsonMetaRepoAdmin(nil)
+			Expect(subject.Create(metaRepoPath)).To(Succeed())
+		})
+
+		It("returns an error, given a path containing marmot data", func() {
+			marmotDataDir := filepath.Join(metaRepoPath, ".marmot")
+			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
 
 			subject = jsonMetaRepoAdmin(nil)
 			Expect(subject.Create(metaRepoPath)).To(
-				MatchError(fmt.Sprintf("path already exists: %s", metaRepoPath)))
+				MatchError(fmt.Sprintf("path already exists: %s", marmotDataDir)))
 		})
 
 		It("returns an error when unable to check if the path exists", func() {


### PR DESCRIPTION
# Changes

## Primary change

Update `remote register` to accept input from standard input (e.g. piped from
another process) when an arg `-` is given.

## Supporting changes

- Update `marmot init` to allow `~/meta` to exist, as long as `~/meta/.marmot` does not.
- Trim arguments and input lines, ignoring blanks
- Add `cspell` configuration and related tool documentation

## Future work

- Will it keep on working to use a single `rootParamParser`, `rootParams` and `AppConfig`?
- Write automated tests for the functional parts of the `cli` package?

## Version

Same
