### PR TITLE
Install go program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Marmot
+# Project
 
 .PHONY: default
 default: all

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,10 @@ debug: path-debug #> Show debugging information
 .PHONY: help
 help: #> Show this help
 	@sed -n \
-		-e '/@sed/!s/#[.] */_\n/p' \
+		-e '/@sed/!s/#[.] */_margin_\n/p' \
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
-	| column -ts :
-
+	| column -ts : | sed -e 's/_margin_//'
 
 #. HOMEBREW TARGETS
 

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,6 @@ uninstall: #> Uninstall programs and manuals
 
 #. OTHER TARGETS
 
-.PHONY: debug
-.NOTPARALLEL: debug
-debug: #> Show debugging information
-	$(MAKE) -C man debug
-	$(MAKE) -C src/go debug
-	$(MAKE) -C src/zsh debug
-
 # https://stackoverflow.com/a/47107132/112682
 .PHONY: help
 help: #> Show this help
@@ -62,6 +55,13 @@ help-all: help #> Show help for all Makefiles
 	$(MAKE) -C man help
 	$(MAKE) -C src/go help
 	$(MAKE) -C src/zsh help
+
+.PHONY: info
+.NOTPARALLEL: info
+info: #> Show build information
+	$(MAKE) -C man info
+	$(MAKE) -C src/go info
+	$(MAKE) -C src/zsh info
 
 install-tools: pre-commit-install #> Install development tools
 	$(MAKE) -C man install-tools

--- a/Makefile
+++ b/Makefile
@@ -7,26 +7,6 @@ default: all
 
 ### Paths
 
-prefix ?= /usr/local
-exec_prefix ?= $(prefix)
-bindir := $(exec_prefix)/bin
-
-datarootdir := $(prefix)/share
-mandir := $(datarootdir)/man
-man1dir := $(mandir)/man1
-
-.PHONY: debug-path
-debug-path:
-	$(info Installation paths:)
-	$(info - prefix: $(prefix))
-	$(info - exec_prefix: $(exec_prefix))
-	$(info - bindir: $(bindir))
-
-	$(info Data paths:)
-	$(info - datarootdir: $(datarootdir))
-	$(info - mandir: $(mandir))
-	$(info - man1dir: $(man1dir))
-
 ### Programs
 
 ### Sources
@@ -63,7 +43,7 @@ uninstall: #> Uninstall programs and manuals
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: debug-path #> Show debugging information
+debug: #> Show debugging information
 	$(MAKE) -C man debug
 	$(MAKE) -C src/go debug
 	$(MAKE) -C src/zsh debug

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: #> Build all sources
 	$(MAKE) -C src/go all
 	$(MAKE) -C src/zsh all
 
-clean: pre-commit-clean #> Remove files that make built
+clean: pre-commit-clean #> Remove local files from builds
 	$(MAKE) -C man clean
 	$(MAKE) -C src/go clean
 	$(MAKE) -C src/zsh clean
@@ -75,16 +75,17 @@ debug: path-debug #> Show debugging information
 .PHONY: help
 help: #> Show this help
 	@sed -n \
-		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/#[.] */_\n/p' \
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
-		| column -ts :
+	| column -ts :
+
 
 #. HOMEBREW TARGETS
 
 .NOTPARALLEL: brew-install
 .PHONY: brew-install
-brew-install: brew-developer-install brew-user-install pre-commit-install #> Install depenedencies with Homebrew
+brew-install: brew-developer-install brew-user-install pre-commit-install #> Install dependencies with Homebrew
 	@:
 
 .PHONY: brew-developer-install

--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,17 @@ PRECOMMIT ?= pre-commit
 #. STANDARD TARGETS
 
 .PHONY: all clean install test uninstall
-all: #> Build everything
+all: #> Build all sources
 	$(MAKE) -C man all
 	$(MAKE) -C src/go all
 	$(MAKE) -C src/zsh all
 
-clean: pre-commit-clean #> Remove files built by running make earlier
+clean: pre-commit-clean #> Remove files that make built
 	$(MAKE) -C man clean
 	$(MAKE) -C src/go clean
 	$(MAKE) -C src/zsh clean
 
-install: #> Install programs and manuals made here
+install: #> Install programs and manuals
 	$(MAKE) -C man install
 	$(MAKE) -C src/go install
 	$(MAKE) -C src/zsh install

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ help: #> Show this help
 		$(MAKEFILE_LIST) \
 	| column -ts : | sed -e 's/_margin_//'
 
+.PHONY: help-all
+help-all: help #> Show help for all Makefiles
+	$(MAKE) -C man help
+	$(MAKE) -C src/go help
+	$(MAKE) -C src/zsh help
+
 install-tools: pre-commit-install #> Install development tools
 	$(MAKE) -C man install-tools
 	$(MAKE) -C src/go install-tools

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: all
 
 ## Environment
 
-### Installation directories
+### Paths
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)
@@ -15,8 +15,8 @@ datarootdir := $(prefix)/share
 mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
 
-.PHONY: path-debug
-path-debug:
+.PHONY: debug-path
+debug-path:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
@@ -63,7 +63,7 @@ uninstall: #> Uninstall programs and manuals
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug #> Show debugging information
+debug: debug-path #> Show debugging information
 	$(MAKE) -C man debug
 	$(MAKE) -C src/go debug
 	$(MAKE) -C src/zsh debug

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: #> Build all sources
 	$(MAKE) -C src/go all
 	$(MAKE) -C src/zsh all
 
-clean: pre-commit-clean #> Remove local files from builds
+clean: pre-commit-gc #> Remove local files from builds
 	$(MAKE) -C man clean
 	$(MAKE) -C src/go clean
 	$(MAKE) -C src/zsh clean
@@ -97,16 +97,16 @@ brew-user-install: #> Use HomeBrew to install dependencies that users need to ru
 
 #. PRE-COMMIT TARGETS
 
-.PHONY: pre-commit-clean
-pre-commit-clean: #> Remove pre-commit files that are no longer referenced
+.PHONY: pre-commit-gc
+pre-commit-gc: #> Remove stale pre-commit files
 	$(PRECOMMIT) gc
 
 .PHONY: pre-commit-install
-pre-commit-install: #> Install Git hooks
+pre-commit-install: #> Install Git pre-commit hook
 	$(PRECOMMIT) install
 
 .PHONY: pre-commit-run
-pre-commit-run: #> Run pre-commit hooks on all Git files
+pre-commit-run: #> Run pre-commit on all sources
 	$(PRECOMMIT) run --all-files
 
 .PHONY: pre-commit-update

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,6 @@ path-debug:
 
 ### Programs
 
-BREW ?= brew
-PRECOMMIT ?= pre-commit
-
 ### Sources
 
 #. STANDARD TARGETS
@@ -80,7 +77,14 @@ help: #> Show this help
 		$(MAKEFILE_LIST) \
 	| column -ts : | sed -e 's/_margin_//'
 
+install-tools: pre-commit-install #> Install development tools
+	$(MAKE) -C man install-tools
+	$(MAKE) -C src/go install-tools
+	$(MAKE) -C src/zsh install-tools
+
 #. HOMEBREW TARGETS
+
+BREW ?= brew
 
 .NOTPARALLEL: brew-install
 .PHONY: brew-install
@@ -96,6 +100,8 @@ brew-install-user: #> Install end-user dependencies with HomeBrew
 	$(BREW) bundle install --file=./etc/macos/Brewfile.user
 
 #. PRE-COMMIT TARGETS
+
+PRECOMMIT ?= pre-commit
 
 .PHONY: pre-commit-gc
 pre-commit-gc: #> Remove stale pre-commit files

--- a/Makefile
+++ b/Makefile
@@ -13,27 +13,31 @@ default: all
 
 #. STANDARD TARGETS
 
-.PHONY: all clean install test uninstall
+.PHONY: all
 all: #> Build all sources
 	$(MAKE) -C man all
 	$(MAKE) -C src/go all
 	$(MAKE) -C src/zsh all
 
+.PHONY: clean
 clean: pre-commit-gc #> Remove local build files
 	$(MAKE) -C man clean
 	$(MAKE) -C src/go clean
 	$(MAKE) -C src/zsh clean
 
+.PHONY: install
 install: #> Install programs and manuals
 	$(MAKE) -C man install
 	$(MAKE) -C src/go install
 	$(MAKE) -C src/zsh install
 
+.PHONY: test
 test: pre-commit-run #> Run tests and checks
 	$(MAKE) -C man test
 	$(MAKE) -C src/go test
 	$(MAKE) -C src/zsh test
 
+.PHONY: uninstall
 uninstall: #> Uninstall programs and manuals
 	$(MAKE) -C man uninstall
 	$(MAKE) -C src/go uninstall

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: #> Build all sources
 	$(MAKE) -C src/go all
 	$(MAKE) -C src/zsh all
 
-clean: pre-commit-gc #> Remove local files from builds
+clean: pre-commit-gc #> Remove local build files
 	$(MAKE) -C man clean
 	$(MAKE) -C src/go clean
 	$(MAKE) -C src/zsh clean
@@ -52,12 +52,12 @@ install: #> Install programs and manuals
 	$(MAKE) -C src/go install
 	$(MAKE) -C src/zsh install
 
-test: pre-commit-run #> Run all tests and checks
+test: pre-commit-run #> Run tests and checks
 	$(MAKE) -C man test
 	$(MAKE) -C src/go test
 	$(MAKE) -C src/zsh test
 
-uninstall: #> Uninstall programs and manuals made here
+uninstall: #> Uninstall programs and manuals
 	$(MAKE) -C man uninstall
 	$(MAKE) -C src/go uninstall
 	$(MAKE) -C src/zsh uninstall
@@ -84,15 +84,15 @@ help: #> Show this help
 
 .NOTPARALLEL: brew-install
 .PHONY: brew-install
-brew-install: brew-developer-install brew-user-install pre-commit-install #> Install dependencies with Homebrew
+brew-install: brew-install-dev brew-install-user pre-commit-install #> Install dependencies with Homebrew
 	@:
 
-.PHONY: brew-developer-install
-brew-developer-install: #> Use HomeBrew to install dependencies that developers need to work here
+.PHONY: brew-install-dev
+brew-install-dev: #> Install development tools with HomeBrew
 	$(BREW) bundle install --file=./etc/macos/Brewfile.developer
 
-.PHONY: brew-user-install
-brew-user-install: #> Use HomeBrew to install dependencies that users need to run this
+.PHONY: brew-install-user
+brew-install-user: #> Install end-user dependencies with HomeBrew
 	$(BREW) bundle install --file=./etc/macos/Brewfile.user
 
 #. PRE-COMMIT TARGETS

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -23,6 +23,7 @@ words:
   - fswatch
   - kkrull
   - Krull
+  - NOTPARALLEL
   - Pandoc
   - pflag
   - svcfs

--- a/man/Makefile
+++ b/man/Makefile
@@ -76,13 +76,14 @@ uninstall: groff-manual-uninstall #> Uninstall man pages
 debug: debug-path debug-sources debug-groff-manual debug-markdown-manual #> Show debugging information
 	@:
 
+# https://stackoverflow.com/a/47107132/112682
 .PHONY: help
 help: #> Show this help
 	@sed -n \
-		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/#[.] */_margin_\n/p' \
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
-		| column -ts :
+	| column -ts : | sed -e 's/_margin_//'
 
 .PHONY: install-tools
 install-tools:

--- a/man/Makefile
+++ b/man/Makefile
@@ -7,7 +7,7 @@ default: all
 
 ## Environment
 
-### Installation directories
+### Paths
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)

--- a/man/Makefile
+++ b/man/Makefile
@@ -42,19 +42,23 @@ source-info:
 
 #. STANDARD TARGETS
 
-.PHONY: all clean install test uninstall
+.PHONY: all
 all: groff-manual markdown-manual #> Build all manuals
 	@:
 
+.PHONY: clean
 clean: groff-manual-clean markdown-manual-clean #> Remove built manuals
 	@:
 
+.PHONY: install
 install: groff-manual-install #> Install man pages to $(mandir)
 	@:
 
+.PHONY: test
 test:
 	@:
 
+.PHONY: uninstall
 uninstall: groff-manual-uninstall #> Uninstall man pages
 	@:
 
@@ -96,10 +100,10 @@ groff-manual-clean: #> Remove built man pages
 
 .PHONY: groff-manual-info
 groff-manual-info: #> Show build information for groff
-	$(info Groff Manual (man pages):)
-	$(info - groff_manual_installed: $(groff_manual_installed))
+	$(info Groff Manual:)
 	$(info - groff_man1_objects: $(groff_man1_objects))
 	$(info - groff_man7_objects: $(groff_man7_objects))
+	$(info - groff_manual_installed: $(groff_manual_installed))
 
 .PHONY: groff-manual-install
 groff-manual-install: $(groff_man1_objects) $(groff_man7_objects) #> Install man pages

--- a/man/Makefile
+++ b/man/Makefile
@@ -18,8 +18,8 @@ mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
 man7dir := $(mandir)/man7
 
-.PHONY: path-debug
-path-debug:
+.PHONY: debug-path
+debug-path:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
@@ -44,8 +44,8 @@ sources := $(wildcard pandoc/**.md)
 sources_man1 := $(filter %.1.md,$(sources))
 sources_man7 := $(filter %.7.md,$(sources))
 
-.PHONY: source-debug
-source-debug:
+.PHONY: debug-sources
+debug-sources:
 	$(info Sources:)
 	$(info - sources: $(sources))
 	$(info - sources_man1: $(sources_man1))
@@ -73,7 +73,7 @@ uninstall: groff-manual-uninstall #> Uninstall man pages
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug source-debug groff-manual-debug markdown-manual-debug #> Show debugging information
+debug: debug-path debug-sources debug-groff-manual debug-markdown-manual #> Show debugging information
 	@:
 
 .PHONY: help
@@ -101,8 +101,8 @@ groff-manual: $(groff_man1_objects) $(groff_man7_objects) #> Build man pages
 groff-manual-clean:
 	$(RM) groff/**
 
-.PHONY: groff-manual-debug
-groff-manual-debug:
+.PHONY: debug-groff-manual
+debug-groff-manual:
 	$(info Groff Manual (man pages):)
 	$(info - groff_manual_installed: $(groff_manual_installed))
 	$(info - groff_man1_objects: $(groff_man1_objects))
@@ -144,8 +144,8 @@ markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are 
 markdown-manual-clean:
 	$(RM) markdown/**.md
 
-.PHONY: markdown-manual-debug
-markdown-manual-debug:
+.PHONY: debug-markdown-manual
+debug-markdown-manual:
 	$(info Markdown Manual:)
 	$(info - markdown_manual_objects: $(markdown_manual_objects))
 	$(info - markdown_manual_objects_dir: $(markdown_manual_objects_dir))

--- a/man/Makefile
+++ b/man/Makefile
@@ -84,6 +84,10 @@ help: #> Show this help
 		$(MAKEFILE_LIST) \
 		| column -ts :
 
+.PHONY: install-tools
+install-tools:
+	@:
+
 #. GROFF MANUAL TARGETS
 
 groff_manual_installed := $(wildcard $(man1dir)/marmot* $(man7dir)/marmot*)

--- a/man/Makefile
+++ b/man/Makefile
@@ -9,10 +9,6 @@ default: all
 
 ### Paths
 
-prefix ?= /usr/local
-exec_prefix ?= $(prefix)
-bindir := $(exec_prefix)/bin
-
 datarootdir := $(prefix)/share
 mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
@@ -20,11 +16,6 @@ man7dir := $(mandir)/man7
 
 .PHONY: debug-path
 debug-path:
-	$(info Installation paths:)
-	$(info - prefix: $(prefix))
-	$(info - exec_prefix: $(exec_prefix))
-	$(info - bindir: $(bindir))
-
 	$(info Data paths:)
 	$(info - datarootdir: $(datarootdir))
 	$(info - mandir: $(mandir))
@@ -33,8 +24,6 @@ debug-path:
 
 ### Programs
 
-FSWATCH ?= fswatch
-MANDOC ?= mandoc
 PANDOC ?= pandoc
 PANDOCFLAGS := -f markdown+definition_lists+line_blocks
 
@@ -91,6 +80,9 @@ install-tools:
 
 #. GROFF MANUAL TARGETS
 
+FSWATCH ?= fswatch
+MANDOC ?= mandoc
+
 groff_manual_installed := $(wildcard $(man1dir)/marmot* $(man7dir)/marmot*)
 groff_man1_objects := $(patsubst pandoc/%.md,groff/%,$(sources_man1))
 groff_man7_objects := $(patsubst pandoc/%.md,groff/%,$(sources_man7))
@@ -99,18 +91,18 @@ groff_man7_objects := $(patsubst pandoc/%.md,groff/%,$(sources_man7))
 groff-manual: $(groff_man1_objects) $(groff_man7_objects) #> Build man pages
 
 .PHONY: groff-manual-clean
-groff-manual-clean:
+groff-manual-clean: #> Remove built man pages
 	$(RM) groff/**
 
 .PHONY: debug-groff-manual
-debug-groff-manual:
+debug-groff-manual: #> Show debugging information for groff
 	$(info Groff Manual (man pages):)
 	$(info - groff_manual_installed: $(groff_manual_installed))
 	$(info - groff_man1_objects: $(groff_man1_objects))
 	$(info - groff_man7_objects: $(groff_man7_objects))
 
 .PHONY: groff-manual-install
-groff-manual-install: $(groff_man1_objects) $(groff_man7_objects)
+groff-manual-install: $(groff_man1_objects) $(groff_man7_objects) #> Install man pages
 	mkdir -p $(man1dir) $(man7dir)
 	install -g 0 -o 0 -m 0644 $(groff_man1_objects) $(man1dir)
 	install -g 0 -o 0 -m 0644 $(groff_man7_objects) $(man7dir)
@@ -121,7 +113,7 @@ groff-manual-preview: #> Render man pages without building or installing
 		| $(MANDOC)
 
 .PHONY: groff-manual-uninstall
-groff-manual-uninstall:
+groff-manual-uninstall: #> Uninstall man pages
 	$(RM) $(groff_manual_installed)
 
 .PHONY: groff-manual-watch
@@ -142,11 +134,11 @@ markdown_manual_objects_dir := markdown
 markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are part of this repo
 
 .PHONY: markdown-manual-clean
-markdown-manual-clean:
+markdown-manual-clean: #> Remove local markdown manuals
 	$(RM) markdown/**.md
 
 .PHONY: debug-markdown-manual
-debug-markdown-manual:
+debug-markdown-manual: #> Show debugging information for markdown manual
 	$(info Markdown Manual:)
 	$(info - markdown_manual_objects: $(markdown_manual_objects))
 	$(info - markdown_manual_objects_dir: $(markdown_manual_objects_dir))

--- a/man/Makefile
+++ b/man/Makefile
@@ -14,9 +14,9 @@ mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
 man7dir := $(mandir)/man7
 
-.PHONY: debug-paths
-debug-paths:
-	$(info Data paths:)
+.PHONY: path-info
+path-info:
+	$(info Paths:)
 	$(info - datarootdir: $(datarootdir))
 	$(info - mandir: $(mandir))
 	$(info - man1dir: $(man1dir))
@@ -33,8 +33,8 @@ sources := $(wildcard pandoc/**.md)
 sources_man1 := $(filter %.1.md,$(sources))
 sources_man7 := $(filter %.7.md,$(sources))
 
-.PHONY: debug-sources
-debug-sources:
+.PHONY: source-info
+source-info:
 	$(info Sources:)
 	$(info - sources: $(sources))
 	$(info - sources_man1: $(sources_man1))
@@ -60,11 +60,6 @@ uninstall: groff-manual-uninstall #> Uninstall man pages
 
 #. OTHER TARGETS
 
-.PHONY: debug
-.NOTPARALLEL: debug
-debug: debug-paths debug-sources debug-groff-manual debug-markdown-manual #> Show debugging information
-	@:
-
 # https://stackoverflow.com/a/47107132/112682
 .PHONY: help
 help: #> Show this help
@@ -73,6 +68,11 @@ help: #> Show this help
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
 	| column -ts : | sed -e 's/_margin_//'
+
+.PHONY: info
+.NOTPARALLEL: info
+info: path-info source-info groff-manual-info markdown-manual-info #> Show build information
+	@:
 
 .PHONY: install-tools
 install-tools:
@@ -94,8 +94,8 @@ groff-manual: $(groff_man1_objects) $(groff_man7_objects) #> Build man pages
 groff-manual-clean: #> Remove built man pages
 	$(RM) groff/**
 
-.PHONY: debug-groff-manual
-debug-groff-manual: #> Show debugging information for groff
+.PHONY: groff-manual-info
+groff-manual-info: #> Show build information for groff
 	$(info Groff Manual (man pages):)
 	$(info - groff_manual_installed: $(groff_manual_installed))
 	$(info - groff_man1_objects: $(groff_man1_objects))
@@ -137,8 +137,8 @@ markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are 
 markdown-manual-clean: #> Remove local markdown manuals
 	$(RM) markdown/**.md
 
-.PHONY: debug-markdown-manual
-debug-markdown-manual: #> Show debugging information for markdown manual
+.PHONY: markdown-manual-info
+markdown-manual-info: #> Show build information for the markdown manual
 	$(info Markdown Manual:)
 	$(info - markdown_manual_objects: $(markdown_manual_objects))
 	$(info - markdown_manual_objects_dir: $(markdown_manual_objects_dir))

--- a/man/Makefile
+++ b/man/Makefile
@@ -14,8 +14,8 @@ mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
 man7dir := $(mandir)/man7
 
-.PHONY: debug-path
-debug-path:
+.PHONY: debug-paths
+debug-paths:
 	$(info Data paths:)
 	$(info - datarootdir: $(datarootdir))
 	$(info - mandir: $(mandir))
@@ -62,7 +62,7 @@ uninstall: groff-manual-uninstall #> Uninstall man pages
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: debug-path debug-sources debug-groff-manual debug-markdown-manual #> Show debugging information
+debug: debug-paths debug-sources debug-groff-manual debug-markdown-manual #> Show debugging information
 	@:
 
 # https://stackoverflow.com/a/47107132/112682

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -12,7 +12,7 @@ ifeq ($(OS),Windows_NT)
 	executable ?= marmot.exe
 endif
 
-debug-artifacts:
+artifact-info:
 	$(info Artifacts:)
 	$(info - executable: $(executable))
 	$(info - OS: $(OS))
@@ -25,8 +25,8 @@ exec_prefix ?= $(prefix)
 bindir := $(exec_prefix)/bin
 artifactdir := $(prefix)/marmot
 
-.PHONY: debug-paths
-debug-paths:
+.PHONY: path-info
+path-info:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
@@ -41,7 +41,7 @@ debug-paths:
 source_main := main.go
 sources := $(shell find . -type f -name '*.go' | sort)
 
-debug-sources: #> Show debugging information
+source-info:
 	$(info Sources:)
 	$(info - source_main: $(source_main))
 	$(info - sources: $(sources))
@@ -77,10 +77,6 @@ uninstall: #> Uninstall program
 
 #. OTHER TARGETS
 
-.PHONY: debug
-debug: debug-artifacts debug-paths debug-sources #> Show debugging information
-	@:
-
 # https://stackoverflow.com/a/47107132/112682
 .PHONY: help
 help: #> Show this help
@@ -89,6 +85,11 @@ help: #> Show this help
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
 	| column -ts : | sed -e 's/_margin_//'
+
+.PHONY: info
+.NOTPARALLEL: info
+info: artifact-info path-info source-info #> Show build information
+	@:
 
 .PHONY: install-tools
 install-tools: #> Install Go development tools

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -57,10 +57,11 @@ all: $(executable) #> Build all sources
 clean: #> Remove local build files
 	$(RM) $(executable)
 
+# TODO KDK: Find a place for the version file to go in /usr/local/marmot and then read that
 .PHONY: install
 install: $(executable) #> Install program
 	mkdir -p $(artifactdir)
-	install -g 0 -o 0 -m 0644 $(executable) $(artifactdir)
+	install -g 0 -o 0 -m 0755 $(executable) $(artifactdir)
 
 	mkdir -p $(bindir)
 	ln -f -s $(artifactdir)/$(executable) $(bindir)/marmot
@@ -71,8 +72,8 @@ test: #> Run tests
 
 .PHONY: uninstall
 uninstall: #> Uninstall program
+	$(RM) -R $(artifactdir)
 	$(RM) $(bindir)/marmot
-	$(RM) -Rf $(artifactdir)
 
 #. OTHER TARGETS
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -23,6 +23,7 @@ debug-artifacts:
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)
 bindir := $(exec_prefix)/bin
+artifactdir := $(prefix)/marmot
 
 .PHONY: debug-paths
 debug-paths:
@@ -30,6 +31,7 @@ debug-paths:
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
 	$(info - bindir: $(bindir))
+	$(info - artifactdir: $(artifactdir))
 
 ### Programs
 
@@ -55,19 +57,22 @@ all: $(executable) #> Build all sources
 clean: #> Remove local build files
 	$(RM) $(executable)
 
-# TODO KDK: Implement install
 .PHONY: install
 install: $(executable) #> Install program
-	@:
+	mkdir -p $(artifactdir)
+	install -g 0 -o 0 -m 0644 $(executable) $(artifactdir)
+
+	mkdir -p $(bindir)
+	ln -f -s $(artifactdir)/$(executable) $(bindir)/marmot
 
 .PHONY: test
 test: #> Run tests
 	ginkgo run -r
 
-# TODO KDK: Implement uninstall
 .PHONY: uninstall
 uninstall: #> Uninstall program
 	$(RM) $(bindir)/marmot
+	$(RM) -Rf $(artifactdir)
 
 #. OTHER TARGETS
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -14,6 +14,26 @@ endif
 
 ### Paths
 
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir := $(exec_prefix)/bin
+
+datarootdir := $(prefix)/share
+mandir := $(datarootdir)/man
+man1dir := $(mandir)/man1
+
+.PHONY: debug-path
+debug-path:
+	$(info Installation paths:)
+	$(info - prefix: $(prefix))
+	$(info - exec_prefix: $(exec_prefix))
+	$(info - bindir: $(bindir))
+
+	$(info Data paths:)
+	$(info - datarootdir: $(datarootdir))
+	$(info - mandir: $(mandir))
+	$(info - man1dir: $(man1dir))
+
 ### Programs
 
 ### Sources
@@ -25,25 +45,31 @@ sources := $(shell find . -type f -name '*.go' | sort)
 #. STANDARD TARGETS
 
 .PHONY: all
-all: $(executable)
+all: $(executable) #> Build all sources
 	@:
 
 .PHONY: clean
-clean:
+clean: #> Remove local build files
 	$(RM) $(executable)
 
+# TODO KDK: Implement install
 .PHONY: install
-install: $(executable)
+install: $(executable) #> Install program
 	@:
 
 .PHONY: test
-test:
+test: #> Run tests
 	ginkgo run -r
+
+# TODO KDK: Implement uninstall
+.PHONY: uninstall
+uninstall: #> Uninstall program
+	$(RM) $(bindir)/marmot
 
 #. OTHER TARGETS
 
 .PHONY: debug
-debug:
+debug: #> Show debugging information
 	$(info OS: $(OS))
 	$(info - executable: $(executable))
 	$(info - source_main: $(source_main))
@@ -60,7 +86,7 @@ help: #> Show this help
 	| column -ts : | sed -e 's/_margin_//'
 
 .PHONY: install-tools
-install-tools:
+install-tools: #> Install Go development tools
 	go install github.com/go-delve/delve/cmd/dlv@latest
 	go install github.com/onsi/ginkgo/v2/ginkgo
 	go install github.com/spf13/cobra-cli@latest
@@ -68,25 +94,25 @@ install-tools:
 	go install mvdan.cc/gofumpt@latest
 
 .PHONY: test-watch
-test-watch: ginkgo-watch
+test-watch: ginkgo-watch #> Run tests in watch mode
 	ginkgo watch -r
 
 #. GO TARGETS
 
 .PHONY: format
-format:
+format: #> Format sources
 	gofumpt -l -w .
 
 .PHONY: run
-run:
+run: #> Run the program
 	go run .
 
 .PHONY: tidy
-tidy:
+tidy: #> Tidy Go module dependencies
 	go mod tidy
 
 .PHONY: update
-update:
+update: #> Update Go dependencies
 	go get -t -u -v
 
 $(executable): $(sources)

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -78,12 +78,13 @@ clean: #> Remove local build files
 install: $(executable) #> Install program
 	mkdir -p $(libexecdirpkg)
 	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
+	install -g 0 -o 0 -m 0644 $(versionfile) $(libexecdirpkg)
 
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
-	mkdir -p $(datadirpkg)
-	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
+#	mkdir -p $(datadirpkg)
+#	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
 
 .PHONY: test
 test: #> Run tests
@@ -91,7 +92,7 @@ test: #> Run tests
 
 .PHONY: uninstall
 uninstall: #> Uninstall program
-	$(RM) -R $(datadirpkg)
+#	$(RM) -R $(datadirpkg)
 	$(RM) -R $(libexecdirpkg)
 	$(RM) $(bindir)/marmot
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -73,12 +73,10 @@ all: $(executable) #> Build all sources
 clean: #> Remove local build files
 	$(RM) $(executable)
 
-# TODO KDK: Find a place for the version file to go in /usr/local/marmot and then read that
 .PHONY: install
 install: $(executable) #> Install program
 	mkdir -p $(libexecdirpkg)
 	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
-#	install -g 0 -o 0 -m 0644 $(versionfile) $(libexecdirpkg)
 
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
@@ -92,9 +90,9 @@ test: #> Run tests
 
 .PHONY: uninstall
 uninstall: #> Uninstall program
+	$(RM) $(bindir)/marmot
 	$(RM) -R $(datadirpkg)
 	$(RM) -R $(libexecdirpkg)
-	$(RM) $(bindir)/marmot
 
 #. OTHER TARGETS
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -22,15 +22,29 @@ artifact-info:
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)
+
+# Executable programs that users can run (including symlinks)
 bindir := $(exec_prefix)/bin
-artifactdir := $(prefix)/marmot
+
+# Executable programs to be run by other programs, in a subdirectory thereof
+libexecdir := $(exec_prefix)/libexec
+libexecdirpkg := $(libexecdir)/marmot
+
+# Read-only architecture-independent data files, in a subdirectory thereof
+datarootdir := $(prefix)/share
+datadir := $(datarootdir)
+datadirpkg := $(datadir)/marmot
 
 .PHONY: path-info
 path-info:
 	$(info Paths:)
-	$(info - artifactdir: $(artifactdir))
 	$(info - bindir: $(bindir))
+	$(info - datadir: $(datadir))
+	$(info - datadirpkg: $(datadirpkg))
+	$(info - datarootdir: $(datarootdir))
 	$(info - exec_prefix: $(exec_prefix))
+	$(info - libexecdir: $(libexecdir))
+	$(info - libexecdirpkg: $(libexecdirpkg))
 	$(info - prefix: $(prefix))
 
 ### Programs
@@ -40,11 +54,13 @@ path-info:
 # NB: the wildcard function is not recursive: https://stackoverflow.com/a/2483203/112682
 source_main := main.go
 sources := $(shell find . -type f -name '*.go' | sort)
+versionfile := version
 
 source-info:
 	$(info Sources:)
 	$(info - source_main: $(source_main))
 	$(info - sources: $(sources))
+	$(info - versionfile: $(versionfile))
 	@:
 
 #. STANDARD TARGETS
@@ -60,11 +76,14 @@ clean: #> Remove local build files
 # TODO KDK: Find a place for the version file to go in /usr/local/marmot and then read that
 .PHONY: install
 install: $(executable) #> Install program
-	mkdir -p $(artifactdir)
-	install -g 0 -o 0 -m 0755 $(executable) $(artifactdir)
+	mkdir -p $(libexecdirpkg)
+	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
 
 	mkdir -p $(bindir)
-	ln -f -s $(artifactdir)/$(executable) $(bindir)/marmot
+	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
+
+	mkdir -p $(datadirpkg)
+	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
 
 .PHONY: test
 test: #> Run tests
@@ -72,7 +91,8 @@ test: #> Run tests
 
 .PHONY: uninstall
 uninstall: #> Uninstall program
-	$(RM) -R $(artifactdir)
+	$(RM) -R $(datadirpkg)
+	$(RM) -R $(libexecdirpkg)
 	$(RM) $(bindir)/marmot
 
 #. OTHER TARGETS

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -78,13 +78,13 @@ clean: #> Remove local build files
 install: $(executable) #> Install program
 	mkdir -p $(libexecdirpkg)
 	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
-	install -g 0 -o 0 -m 0644 $(versionfile) $(libexecdirpkg)
+#	install -g 0 -o 0 -m 0644 $(versionfile) $(libexecdirpkg)
 
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
-#	mkdir -p $(datadirpkg)
-#	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
+	mkdir -p $(datadirpkg)
+	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
 
 .PHONY: test
 test: #> Run tests
@@ -92,7 +92,7 @@ test: #> Run tests
 
 .PHONY: uninstall
 uninstall: #> Uninstall program
-#	$(RM) -R $(datadirpkg)
+	$(RM) -R $(datadirpkg)
 	$(RM) -R $(libexecdirpkg)
 	$(RM) $(bindir)/marmot
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -12,27 +12,24 @@ ifeq ($(OS),Windows_NT)
 	executable ?= marmot.exe
 endif
 
+debug-artifacts:
+	$(info Artifacts:)
+	$(info - executable: $(executable))
+	$(info - OS: $(OS))
+	@:
+
 ### Paths
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)
 bindir := $(exec_prefix)/bin
 
-datarootdir := $(prefix)/share
-mandir := $(datarootdir)/man
-man1dir := $(mandir)/man1
-
-.PHONY: debug-path
-debug-path:
+.PHONY: debug-paths
+debug-paths:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
 	$(info - bindir: $(bindir))
-
-	$(info Data paths:)
-	$(info - datarootdir: $(datarootdir))
-	$(info - mandir: $(mandir))
-	$(info - man1dir: $(man1dir))
 
 ### Programs
 
@@ -41,6 +38,12 @@ debug-path:
 # NB: the wildcard function is not recursive: https://stackoverflow.com/a/2483203/112682
 source_main := main.go
 sources := $(shell find . -type f -name '*.go' | sort)
+
+debug-sources: #> Show debugging information
+	$(info Sources:)
+	$(info - source_main: $(source_main))
+	$(info - sources: $(sources))
+	@:
 
 #. STANDARD TARGETS
 
@@ -69,11 +72,7 @@ uninstall: #> Uninstall program
 #. OTHER TARGETS
 
 .PHONY: debug
-debug: #> Show debugging information
-	$(info OS: $(OS))
-	$(info - executable: $(executable))
-	$(info - source_main: $(source_main))
-	$(info - sources: $(sources))
+debug: debug-artifacts debug-paths debug-sources #> Show debugging information
 	@:
 
 # https://stackoverflow.com/a/47107132/112682

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -27,11 +27,11 @@ artifactdir := $(prefix)/marmot
 
 .PHONY: path-info
 path-info:
-	$(info Installation paths:)
-	$(info - prefix: $(prefix))
-	$(info - exec_prefix: $(exec_prefix))
-	$(info - bindir: $(bindir))
+	$(info Paths:)
 	$(info - artifactdir: $(artifactdir))
+	$(info - bindir: $(bindir))
+	$(info - exec_prefix: $(exec_prefix))
+	$(info - prefix: $(prefix))
 
 ### Programs
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -1,11 +1,28 @@
-# Artifact
+# Go
+
+.PHONY: default
+default: all
+
+## Environment
+
+### Artifact
 
 executable ?= marmot
 ifeq ($(OS),Windows_NT)
 	executable ?= marmot.exe
 endif
 
-# Standard-ish targets
+### Paths
+
+### Programs
+
+### Sources
+
+# NB: the wildcard function is not recursive: https://stackoverflow.com/a/2483203/112682
+source_main := main.go
+sources := $(shell find . -type f -name '*.go' | sort)
+
+#. STANDARD TARGETS
 
 .PHONY: all
 all: $(executable)
@@ -20,37 +37,27 @@ install: $(executable)
 	@:
 
 .PHONY: test
-test: ginkgo-run
-	@:
+test:
+	ginkgo run -r
 
-.PHONY: test-watch
-test-watch: ginkgo-watch
-	@:
-
-# Go module targets
-
-# NB: the wildcard function is not recursive: https://stackoverflow.com/a/2483203/112682
-sources := $(shell find . -type f -name '*.go' | sort)
-source_main := main.go
+#. OTHER TARGETS
 
 .PHONY: debug
 debug:
 	$(info OS: $(OS))
 	$(info - executable: $(executable))
+	$(info - source_main: $(source_main))
 	$(info - sources: $(sources))
 	@:
 
-.PHONY: format
-format:
-	gofumpt -l -w .
-
-.PHONY: ginkgo-run
-ginkgo-run:
-	ginkgo run -r
-
-.PHONY: ginkgo-watch
-ginkgo-watch:
-	ginkgo watch -r
+# https://stackoverflow.com/a/47107132/112682
+.PHONY: help
+help: #> Show this help
+	@sed -n \
+		-e '/@sed/!s/#[.] */_margin_\n/p' \
+		-e '/@sed/!s/:.*#> /:/p' \
+		$(MAKEFILE_LIST) \
+	| column -ts : | sed -e 's/_margin_//'
 
 .PHONY: install-tools
 install-tools:
@@ -59,6 +66,16 @@ install-tools:
 	go install github.com/spf13/cobra-cli@latest
 	go install golang.org/x/tools/cmd/godoc@latest
 	go install mvdan.cc/gofumpt@latest
+
+.PHONY: test-watch
+test-watch: ginkgo-watch
+	ginkgo watch -r
+
+#. GO TARGETS
+
+.PHONY: format
+format:
+	gofumpt -l -w .
 
 .PHONY: run
 run:

--- a/src/go/core/version.go
+++ b/src/go/core/version.go
@@ -58,8 +58,15 @@ func readVersion(versionFilename string) (string, error) {
 func versionFilePath() (string, error) {
 	if executablePath, executableErr := os.Executable(); executableErr != nil {
 		return "", executableErr
+	} else if linkTarget, err := filepath.EvalSymlinks(executablePath); err != nil {
+		return "", err
 	} else {
-		programDir := filepath.Dir(executablePath)
-		return filepath.Join(programDir, "version"), nil
+		fmt.Printf("executablePath=%s\n", executablePath)
+		fmt.Printf("linkTarget=%s\n", linkTarget)
+
+		programDir := filepath.Dir(linkTarget)
+		versionPath := filepath.Join(programDir, "version")
+		fmt.Printf("versionPath=%s\n", versionPath)
+		return versionPath, nil
 	}
 }

--- a/src/go/core/version.go
+++ b/src/go/core/version.go
@@ -61,11 +61,9 @@ func versionFilePath() (string, error) {
 	} else if executablePath, linkErr := filepath.EvalSymlinks(maybeSymlinkPath); linkErr != nil {
 		return "", linkErr
 	} else {
-		fmt.Printf("executablePath=%s\n", executablePath)
 		searchPaths := versionFileSearchPaths(executablePath)
 		for _, maybeVersionPath := range searchPaths {
 			if _, statErr := os.Stat(maybeVersionPath); statErr == nil {
-				fmt.Printf("versionFilePath=%s\n", maybeVersionPath)
 				return maybeVersionPath, nil
 			}
 		}

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -51,6 +51,10 @@ install: #> Install symlink from $(bindir) to sources
 	mkdir -p $(bindir)
 	ln -f -s $(srcdir)/marmot.zsh $(bindir)/marmot
 
+.PHONY: install-tools
+install-tools:
+	@:
+
 test:
 	@:
 

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -13,10 +13,10 @@ bindir := $(exec_prefix)/bin
 
 .PHONY: path-info
 path-info:
-	$(info Installation paths:)
-	$(info - prefix: $(prefix))
-	$(info - exec_prefix: $(exec_prefix))
+	$(info Paths:)
 	$(info - bindir: $(bindir))
+	$(info - exec_prefix: $(exec_prefix))
+	$(info - prefix: $(prefix))
 
 ### Programs
 
@@ -31,33 +31,28 @@ source-info:
 
 #. STANDARD TARGETS
 
-.PHONY: all clean install test uninstall
+.PHONY: all
 all:
 	@:
 
+.PHONY: clean
 clean:
 	@:
 
-install: #> Install symlink from $(bindir) to sources
+.PHONY: install
+install: #> Install symlink to sources
 	mkdir -p $(bindir)
 	ln -f -s $(srcdir)/marmot.zsh $(bindir)/marmot
 
-.PHONY: install-tools
-install-tools:
-	@:
-
+.PHONY: test
 test:
 	@:
 
-uninstall: #> Delete symlink from $(bindir)
+.PHONY: uninstall
+uninstall: #> Delete symlink
 	$(RM) $(bindir)/marmot
 
 #. OTHER TARGETS
-
-.PHONY: info
-.NOTPARALLEL: info
-info: path-info source-info #> Show build information
-	@:
 
 # https://stackoverflow.com/a/47107132/112682
 .PHONY: help
@@ -67,3 +62,12 @@ help: #> Show this help
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
 	| column -ts : | sed -e 's/_margin_//'
+
+.PHONY: info
+.NOTPARALLEL: info
+info: path-info source-info #> Show build information
+	@:
+
+.PHONY: install-tools
+install-tools:
+	@:

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -1,11 +1,11 @@
-# Marmot programs
+# Scripts
 
 .PHONY: default
 default: all
 
 ## Environment
 
-### Installation directories
+### Paths
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -11,8 +11,8 @@ prefix ?= /usr/local
 exec_prefix ?= $(prefix)
 bindir := $(exec_prefix)/bin
 
-.PHONY: debug-paths
-debug-paths:
+.PHONY: path-info
+path-info:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
@@ -24,8 +24,8 @@ debug-paths:
 
 srcdir := $(realpath .)
 
-.PHONY: debug-sources
-debug-sources:
+.PHONY: source-info
+source-info:
 	$(info Sources:)
 	$(info - srcdir: $(srcdir))
 
@@ -54,9 +54,9 @@ uninstall: #> Delete symlink from $(bindir)
 
 #. OTHER TARGETS
 
-.PHONY: debug
-.NOTPARALLEL: debug
-debug: debug-paths debug-sources #> Show debugging information
+.PHONY: info
+.NOTPARALLEL: info
+info: path-info source-info #> Show build information
 	@:
 
 # https://stackoverflow.com/a/47107132/112682

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -68,10 +68,11 @@ uninstall: #> Delete symlink from $(bindir)
 debug: debug-path debug-sources #> Show debugging information
 	@:
 
+# https://stackoverflow.com/a/47107132/112682
 .PHONY: help
 help: #> Show this help
 	@sed -n \
-		-e '/@sed/!s/#[.] *//p' \
+		-e '/@sed/!s/#[.] */_margin_\n/p' \
 		-e '/@sed/!s/:.*#> /:/p' \
 		$(MAKEFILE_LIST) \
-		| column -ts :
+	| column -ts : | sed -e 's/_margin_//'

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -11,21 +11,12 @@ prefix ?= /usr/local
 exec_prefix ?= $(prefix)
 bindir := $(exec_prefix)/bin
 
-datarootdir := $(prefix)/share
-mandir := $(datarootdir)/man
-man1dir := $(mandir)/man1
-
-.PHONY: debug-path
-debug-path:
+.PHONY: debug-paths
+debug-paths:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
 	$(info - bindir: $(bindir))
-
-	$(info Data paths:)
-	$(info - datarootdir: $(datarootdir))
-	$(info - mandir: $(mandir))
-	$(info - man1dir: $(man1dir))
 
 ### Programs
 
@@ -65,7 +56,7 @@ uninstall: #> Delete symlink from $(bindir)
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: debug-path debug-sources #> Show debugging information
+debug: debug-paths debug-sources #> Show debugging information
 	@:
 
 # https://stackoverflow.com/a/47107132/112682

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -15,8 +15,8 @@ datarootdir := $(prefix)/share
 mandir := $(datarootdir)/man
 man1dir := $(mandir)/man1
 
-.PHONY: path-debug
-path-debug:
+.PHONY: debug-path
+debug-path:
 	$(info Installation paths:)
 	$(info - prefix: $(prefix))
 	$(info - exec_prefix: $(exec_prefix))
@@ -33,8 +33,8 @@ path-debug:
 
 srcdir := $(realpath .)
 
-.PHONY: source-debug
-source-debug:
+.PHONY: debug-sources
+debug-sources:
 	$(info Sources:)
 	$(info - srcdir: $(srcdir))
 
@@ -65,7 +65,7 @@ uninstall: #> Delete symlink from $(bindir)
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: path-debug source-debug #> Show debugging information
+debug: debug-path debug-sources #> Show debugging information
 	@:
 
 .PHONY: help


### PR DESCRIPTION
# Changes

## Primary change

Add `install` and `uninstall` targets to Go `Makefile`

## Supporting changes

- Standardized targets across Makefiles
- Updated `help` targets in Makefiles
- Look up `version` file next to the executable and in a GNU conventional datadir
