### PR TITLE
Fix and extend Makefile for Go

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -8,6 +8,7 @@ default: all
 ## Environment
 
 ### Paths
+prefix ?= /usr/local
 
 datarootdir := $(prefix)/share
 mandir := $(datarootdir)/man
@@ -21,6 +22,7 @@ path-info:
 	$(info - mandir: $(mandir))
 	$(info - man1dir: $(man1dir))
 	$(info - man7dir: $(man7dir))
+	$(info - prefix: $(prefix))
 
 ### Programs
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -8,6 +8,7 @@ default: all
 ## Environment
 
 ### Paths
+
 prefix ?= /usr/local
 
 datarootdir := $(prefix)/share

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -1,3 +1,3 @@
+_marmot
 marmot
 marmot.exe
-marmot.zsh

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -1,2 +1,3 @@
 marmot
 marmot.exe
+marmot.zsh

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -7,6 +7,8 @@ default: all
 
 ### Artifact
 
+autocompletezsh := marmot.zsh
+
 executable ?= marmot
 ifeq ($(OS),Windows_NT)
 	executable ?= marmot.exe
@@ -14,6 +16,7 @@ endif
 
 artifact-info:
 	$(info Artifacts:)
+	$(info - autocompletezsh: $(autocompletezsh))
 	$(info - executable: $(executable))
 	$(info - OS: $(OS))
 	@:
@@ -35,12 +38,17 @@ datarootdir := $(prefix)/share
 datadir := $(datarootdir)
 datadirpkg := $(datadir)/marmot
 
+# Autocomplete scripts
+# https://unix.stackexchange.com/a/607810/37734
+datadirzshfn := $(datadir)/zsh/site-functions
+
 .PHONY: path-info
 path-info:
 	$(info Paths:)
 	$(info - bindir: $(bindir))
 	$(info - datadir: $(datadir))
 	$(info - datadirpkg: $(datadirpkg))
+	$(info - datadirzshfn: $(datadirzshfn))
 	$(info - datarootdir: $(datarootdir))
 	$(info - exec_prefix: $(exec_prefix))
 	$(info - libexecdir: $(libexecdir))
@@ -65,24 +73,28 @@ source-info:
 
 #. STANDARD TARGETS
 
+.NOTPARALLEL: all
 .PHONY: all
-all: $(executable) #> Build all sources
+all: $(executable) $(autocompletezsh) #> Build all sources
 	@:
 
 .PHONY: clean
 clean: #> Remove local build files
-	$(RM) $(executable)
+	$(RM) $(autocompletezsh) $(executable)
 
 .PHONY: install
-install: $(executable) #> Install program
-	mkdir -p $(libexecdirpkg)
-	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
-
+install: $(autocompletezsh) $(executable) #> Install program
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
 	mkdir -p $(datadirpkg)
 	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
+
+	mkdir -p $(datadirzshfn)
+	install -g 0 -o 0 -m 0644 $(autocompletezsh) $(datadirzshfn)
+
+	mkdir -p $(libexecdirpkg)
+	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
 
 .PHONY: test
 test: #> Run tests
@@ -92,6 +104,7 @@ test: #> Run tests
 uninstall: #> Uninstall program
 	$(RM) $(bindir)/marmot
 	$(RM) -R $(datadirpkg)
+	$(RM) $(datadirzshfn)/$(autocompletezsh)
 	$(RM) -R $(libexecdirpkg)
 
 #. OTHER TARGETS
@@ -139,6 +152,9 @@ tidy: #> Tidy Go module dependencies
 .PHONY: update
 update: #> Update Go dependencies
 	go get -t -u -v
+
+$(autocompletezsh): $(executable)
+	./$(executable) completion zsh > $(autocompletezsh)
 
 $(executable): $(sources)
 	go build -o $(executable) $(source_main)

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -83,15 +83,12 @@ clean: #> Remove local build files
 	$(RM) $(autocomplete) $(executable)
 
 .PHONY: install
-install: $(autocomplete) $(executable) #> Install program
+install: $(executable) #> Install program
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
 	mkdir -p $(datadirpkg)
 	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
-
-	mkdir -p $(datadirzshfn)
-	install -g 0 -o 0 -m 0644 $(autocomplete) $(datadirzshfn)
 
 	mkdir -p $(libexecdirpkg)
 	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
@@ -122,6 +119,12 @@ help: #> Show this help
 .NOTPARALLEL: info
 info: artifact-info path-info source-info #> Show build information
 	@:
+
+.PHONY: install-autocomplete-zsh
+install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
+	mkdir -p $(datadirzshfn)
+	install -g 0 -o 0 -m 0644 $(autocomplete) $(datadirzshfn)
+	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 
 .PHONY: install-tools
 install-tools: #> Install Go development tools

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -87,11 +87,8 @@ install: $(executable) #> Install program
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
-	mkdir -p $(datadirpkg)
-	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
-
-	mkdir -p $(libexecdirpkg)
-	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
+	install -D -g 0 -o 0 -m 0644 -t $(datadirpkg) $(versionfile)
+	install -D -g 0 -o 0 -m 0755 -t $(libexecdirpkg) $(executable)
 
 .PHONY: test
 test: #> Run tests
@@ -122,8 +119,7 @@ info: artifact-info path-info source-info #> Show build information
 
 .PHONY: install-autocomplete-zsh
 install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
-	mkdir -p $(datadirzshfn)
-	install -g 0 -o 0 -m 0644 $(autocomplete) $(datadirzshfn)
+	install -D -g 0 -o 0 -m 0644 -t $(datadirzshfn) $(autocomplete)
 	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 
 .PHONY: install-tools

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -7,7 +7,7 @@ default: all
 
 ### Artifact
 
-autocompletezsh := marmot.zsh
+autocomplete := _marmot
 
 executable ?= marmot
 ifeq ($(OS),Windows_NT)
@@ -16,7 +16,7 @@ endif
 
 artifact-info:
 	$(info Artifacts:)
-	$(info - autocompletezsh: $(autocompletezsh))
+	$(info - autocomplete: $(autocomplete))
 	$(info - executable: $(executable))
 	$(info - OS: $(OS))
 	@:
@@ -75,15 +75,15 @@ source-info:
 
 .NOTPARALLEL: all
 .PHONY: all
-all: $(executable) $(autocompletezsh) #> Build all sources
+all: $(executable) $(autocomplete) #> Build all sources
 	@:
 
 .PHONY: clean
 clean: #> Remove local build files
-	$(RM) $(autocompletezsh) $(executable)
+	$(RM) $(autocomplete) $(executable)
 
 .PHONY: install
-install: $(autocompletezsh) $(executable) #> Install program
+install: $(autocomplete) $(executable) #> Install program
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
@@ -91,7 +91,7 @@ install: $(autocompletezsh) $(executable) #> Install program
 	install -g 0 -o 0 -m 0644 $(versionfile) $(datadirpkg)
 
 	mkdir -p $(datadirzshfn)
-	install -g 0 -o 0 -m 0644 $(autocompletezsh) $(datadirzshfn)
+	install -g 0 -o 0 -m 0644 $(autocomplete) $(datadirzshfn)
 
 	mkdir -p $(libexecdirpkg)
 	install -g 0 -o 0 -m 0755 $(executable) $(libexecdirpkg)
@@ -104,7 +104,7 @@ test: #> Run tests
 uninstall: #> Uninstall program
 	$(RM) $(bindir)/marmot
 	$(RM) -R $(datadirpkg)
-	$(RM) $(datadirzshfn)/$(autocompletezsh)
+	$(RM) $(datadirzshfn)/$(autocomplete)
 	$(RM) -R $(libexecdirpkg)
 
 #. OTHER TARGETS
@@ -153,8 +153,8 @@ tidy: #> Tidy Go module dependencies
 update: #> Update Go dependencies
 	go get -t -u -v
 
-$(autocompletezsh): $(executable)
-	./$(executable) completion zsh > $(autocompletezsh)
+$(autocomplete): $(executable)
+	./$(executable) completion zsh > $(autocomplete)
 
 $(executable): $(sources)
 	go build -o $(executable) $(source_main)


### PR DESCRIPTION
# Changes

## Primary change

Fix the recipes to install `marmot` built with Go

## Supporting changes

Add target to install autocompletion scripts for zsh

