### PR TITLE
Fix make install

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,10 @@ trim_trailing_whitespace = false
 indent_size = off
 
 [Makefile]
-indent_style = tab
+# Indentation outside of a target's commands must be spaces, leading to mixed tabs/spaces
+# https://stackoverflow.com/a/4713737/112682
+indent_size =
+indent_style =
 
 [{*.go,*.mod,*.sum}]
 indent_style = tab

--- a/man/Makefile
+++ b/man/Makefile
@@ -24,6 +24,7 @@ path-info:
 	$(info - man1dir: $(man1dir))
 	$(info - man7dir: $(man7dir))
 	$(info - prefix: $(prefix))
+	@:
 
 ### Programs
 
@@ -42,6 +43,7 @@ source-info:
 	$(info - sources: $(sources))
 	$(info - sources_man1: $(sources_man1))
 	$(info - sources_man7: $(sources_man7))
+	@:
 
 #. STANDARD TARGETS
 
@@ -107,6 +109,7 @@ groff-manual-info: #> Show build information for groff
 	$(info - groff_man1_objects: $(groff_man1_objects))
 	$(info - groff_man7_objects: $(groff_man7_objects))
 	$(info - groff_manual_installed: $(groff_manual_installed))
+	@:
 
 .PHONY: groff-manual-install
 groff-manual-install: $(groff_man1_objects) $(groff_man7_objects) #> Install man pages
@@ -149,6 +152,7 @@ markdown-manual-info: #> Show build information for the markdown manual
 	$(info Markdown Manual:)
 	$(info - markdown_manual_objects: $(markdown_manual_objects))
 	$(info - markdown_manual_objects_dir: $(markdown_manual_objects_dir))
+	@:
 
 # Make sure directory exists before building targets
 # https://www.gnu.org/savannah-checkouts/gnu/make/manual/html_node/Prerequisite-Types.html

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -104,8 +104,8 @@ install: $(executable) #> Install program
 	mkdir -p $(bindir)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
-	install -D -g 0 -o 0 -m 0644 -t $(datadirpkg) $(versionfile)
-	install -D -g 0 -o 0 -m 0755 -t $(libexecdirpkg) $(executable)
+	install $(INSTALLFLAGS) -m 0644 $(datadirpkg) $(versionfile)
+	install $(INSTALLFLAGS) -m 0755 $(libexecdirpkg) $(executable)
 
 .PHONY: test
 test: #> Run tests
@@ -136,7 +136,7 @@ info: artifact-info path-info program-info source-info #> Show build information
 
 .PHONY: install-autocomplete-zsh
 install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
-	install -D -g 0 -o 0 -m 0644 -t $(datadirzshfn) $(autocomplete)
+	install $(INSTALLFLAGS) -m 0644 $(datadirzshfn) $(autocomplete)
 	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 
 .PHONY: install-tools

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -101,7 +101,7 @@ clean: #> Remove local build files
 
 .PHONY: install
 install: $(executable) #> Install program
-	mkdir -p $(bindir)
+	mkdir -p $(bindir) $(datadirpkg) $(libexecdirpkg)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
 	install $(INSTALLFLAGS) -m 0644 $(datadirpkg) $(versionfile)
@@ -136,6 +136,7 @@ info: artifact-info path-info program-info source-info #> Show build information
 
 .PHONY: install-autocomplete-zsh
 install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
+	mkdir -p $(datadirzshfn)
 	install $(INSTALLFLAGS) -m 0644 $(datadirzshfn) $(autocomplete)
 	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -62,7 +62,7 @@ path-info:
 ### Programs
 
 ifeq ($(shell uname -s),Darwin)
-  INSTALLFLAGS := -d -g 0 -o 0
+  INSTALLFLAGS := -g 0 -o 0
 else
   INSTALLFLAGS := -D -g 0 -o 0
 endif
@@ -104,8 +104,8 @@ install: $(executable) #> Install program
 	mkdir -p $(bindir) $(datadirpkg) $(libexecdirpkg)
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
-	install $(INSTALLFLAGS) -m 0644 $(datadirpkg) $(versionfile)
-	install $(INSTALLFLAGS) -m 0755 $(libexecdirpkg) $(executable)
+	install $(INSTALLFLAGS) -m 0644 $(versionfile) $(datadirpkg)
+	install $(INSTALLFLAGS) -m 0755 $(executable) $(libexecdirpkg)
 
 .PHONY: test
 test: #> Run tests
@@ -137,7 +137,7 @@ info: artifact-info path-info program-info source-info #> Show build information
 .PHONY: install-autocomplete-zsh
 install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
 	mkdir -p $(datadirzshfn)
-	install $(INSTALLFLAGS) -m 0644 $(datadirzshfn) $(autocomplete)
+	install $(INSTALLFLAGS) -m 0644 $(autocomplete) $(datadirzshfn)
 	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 
 .PHONY: install-tools

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -61,11 +61,7 @@ path-info:
 
 ### Programs
 
-ifeq ($(shell uname -s),Darwin)
-  INSTALLFLAGS := -g 0 -o 0
-else
-  INSTALLFLAGS := -D -g 0 -o 0
-endif
+INSTALLFLAGS := -g 0 -o 0
 
 .PHONY: program-info
 program-info:

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -9,11 +9,14 @@ default: all
 
 autocomplete := _marmot
 
+# Indentation must be spaces, when not part of a target's commands
+# https://stackoverflow.com/a/4713737/112682
 executable ?= marmot
 ifeq ($(OS),Windows_NT)
-	executable ?= marmot.exe
+  executable ?= marmot.exe
 endif
 
+.PHONY: artifact-info
 artifact-info:
 	$(info Artifacts:)
 	$(info - autocomplete: $(autocomplete))
@@ -54,8 +57,21 @@ path-info:
 	$(info - libexecdir: $(libexecdir))
 	$(info - libexecdirpkg: $(libexecdirpkg))
 	$(info - prefix: $(prefix))
+	@:
 
 ### Programs
+
+ifeq ($(shell uname -s),Darwin)
+  INSTALLFLAGS := -d -g 0 -o 0
+else
+  INSTALLFLAGS := -D -g 0 -o 0
+endif
+
+.PHONY: program-info
+program-info:
+	$(info Programs:)
+	$(info - INSTALLFLAGS: $(INSTALLFLAGS))
+	@:
 
 ### Sources
 
@@ -64,6 +80,7 @@ source_main := main.go
 sources := $(shell find . -type f -name '*.go' | sort)
 versionfile := version
 
+.PHONY: source-info
 source-info:
 	$(info Sources:)
 	$(info - source_main: $(source_main))
@@ -114,7 +131,7 @@ help: #> Show this help
 
 .PHONY: info
 .NOTPARALLEL: info
-info: artifact-info path-info source-info #> Show build information
+info: artifact-info path-info program-info source-info #> Show build information
 	@:
 
 .PHONY: install-autocomplete-zsh

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -17,6 +17,7 @@ path-info:
 	$(info - bindir: $(bindir))
 	$(info - exec_prefix: $(exec_prefix))
 	$(info - prefix: $(prefix))
+	@:
 
 ### Programs
 
@@ -28,6 +29,7 @@ srcdir := $(realpath .)
 source-info:
 	$(info Sources:)
 	$(info - srcdir: $(srcdir))
+	@:
 
 #. STANDARD TARGETS
 


### PR DESCRIPTION
# Changes

## Primary change

Fix `Makefile` `install` target for Go artifacts, since `install` works
differently for BSD / MacOS.

## Supporting changes

Update `.editorconfig` to avoid indenting things incorrectly

