### PR TITLE
Add commands to Add and list local repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/go/cukefeature/localDir
+
 # Manual
 man/groff/*
 #man/markdown/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-src/go/cukefeature/localDir
-
 # Manual
 man/groff/*
 #man/markdown/*

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -20,6 +20,7 @@ version: "0.2"
 words:
   - cmdremote
   - cmdroot
+  - corerepository
   - fswatch
   - kkrull
   - Krull

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -1,3 +1,7 @@
+# Artifacts
 _marmot
 marmot
 marmot.exe
+
+# Testing
+cukefeature/localDir

--- a/src/go/corerepository/repositories.go
+++ b/src/go/corerepository/repositories.go
@@ -7,6 +7,9 @@ type Repositories interface {
 	// How many repositories are in this collection
 	Count() int
 
+	// Paths to each repository on the local file system
+	LocalPaths() []string
+
 	// String versions of each remote's URL
 	RemoteHrefs() []string
 
@@ -21,6 +24,15 @@ type RepositoriesArray struct {
 
 func (array RepositoriesArray) Count() int {
 	return len(array.Repositories)
+}
+
+func (array RepositoriesArray) LocalPaths() []string {
+	localPaths := make([]string, len(array.Repositories))
+	for i, repository := range array.Repositories {
+		localPaths[i] = repository.LocalPath
+	}
+
+	return localPaths
 }
 
 func (array RepositoriesArray) RemoteHrefs() []string {

--- a/src/go/corerepository/repositories.go
+++ b/src/go/corerepository/repositories.go
@@ -2,6 +2,11 @@ package corerepository
 
 import "net/url"
 
+// Construct a container containing the given repositories.
+func SomeRepositories(repositories []Repository) Repositories {
+	return &RepositoriesArray{Repositories: repositories}
+}
+
 // Construct a container containing no repositories of any kind.
 func NoRepositories() Repositories {
 	return &RepositoriesArray{

--- a/src/go/corerepository/repositories.go
+++ b/src/go/corerepository/repositories.go
@@ -2,6 +2,13 @@ package corerepository
 
 import "net/url"
 
+// Construct a container containing no repositories of any kind.
+func NoRepositories() Repositories {
+	return &RepositoriesArray{
+		Repositories: make([]Repository, 0),
+	}
+}
+
 // Any number of Git repositories.
 type Repositories interface {
 	// How many repositories are in this collection

--- a/src/go/corerepository/repository.go
+++ b/src/go/corerepository/repository.go
@@ -18,5 +18,6 @@ func RemoteRepositoryS(remoteUrl string) (Repository, error) {
 
 // One Git repository.
 type Repository struct {
+	LocalPath string
 	RemoteUrl *url.URL
 }

--- a/src/go/corerepository/repository.go
+++ b/src/go/corerepository/repository.go
@@ -2,9 +2,20 @@ package corerepository
 
 import "net/url"
 
+// Construct a repository with the given path.
+func LocalRepository(localPath string) Repository {
+	return Repository{
+		LocalPath: localPath,
+		RemoteUrl: nil,
+	}
+}
+
 // Construct a repository with a URL to its remote host.
 func RemoteRepository(remoteUrl *url.URL) Repository {
-	return Repository{RemoteUrl: remoteUrl}
+	return Repository{
+		LocalPath: "",
+		RemoteUrl: remoteUrl,
+	}
 }
 
 // Construct a repository with something recognizable as a URL to its remote host.
@@ -12,7 +23,10 @@ func RemoteRepositoryS(remoteUrl string) (Repository, error) {
 	if parsedUrl, parseErr := url.Parse(remoteUrl); parseErr != nil {
 		return Repository{}, parseErr
 	} else {
-		return Repository{RemoteUrl: parsedUrl}, nil
+		return Repository{
+			LocalPath: "",
+			RemoteUrl: parsedUrl,
+		}, nil
 	}
 }
 

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -6,5 +6,6 @@ import "net/url"
 type RepositorySource interface {
 	AddLocal(localPath string) error
 	AddRemote(hostUrl *url.URL) error
+	ListLocal() (Repositories, error)
 	ListRemote() (Repositories, error)
 }

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -4,6 +4,7 @@ import "net/url"
 
 // A source of Git repositories that a meta repo might care about.
 type RepositorySource interface {
+	AddLocal(localPath string) error
 	AddRemote(hostUrl *url.URL) error
 	ListRemote() (Repositories, error)
 }

--- a/src/go/corerepositorymock/repository_source_mock.go
+++ b/src/go/corerepositorymock/repository_source_mock.go
@@ -11,6 +11,7 @@ import (
 
 func NewRepositorySource() *RepositorySource {
 	return &RepositorySource{
+		AddLocalCalls:   make([]string, 0),
 		AddRemoteCalls:  make([]*url.URL, 0),
 		AddRemoteErrors: make(map[string]error),
 		ListRemoteUrls:  make([]*url.URL, 0),
@@ -19,10 +20,20 @@ func NewRepositorySource() *RepositorySource {
 
 // Mock implementation for testing with RepositorySource.
 type RepositorySource struct {
+	AddLocalCalls   []string
 	AddRemoteCalls  []*url.URL
 	AddRemoteErrors map[string]error
 	ListRemoteUrls  []*url.URL
 }
+
+/* Local repositories */
+
+func (source *RepositorySource) AddLocalExpected(expectedPaths ...string) {
+	ginkgo.GinkgoHelper()
+	Expect(source.AddLocalCalls).To(ConsistOf(expectedPaths))
+}
+
+/* Remote repositories */
 
 func (source *RepositorySource) AddRemote(hostUrl *url.URL) error {
 	source.AddRemoteCalls = append(source.AddRemoteCalls, hostUrl)

--- a/src/go/corerepositorymock/repository_source_mock.go
+++ b/src/go/corerepositorymock/repository_source_mock.go
@@ -11,44 +11,44 @@ import (
 
 func NewRepositorySource() *RepositorySource {
 	return &RepositorySource{
-		AddLocalCalls:   make([]string, 0),
-		AddLocalErrors:  make(map[string]error),
-		AddRemoteCalls:  make([]*url.URL, 0),
-		AddRemoteErrors: make(map[string]error),
+		addLocalCalls:   make([]string, 0),
+		addLocalErrors:  make(map[string]error),
+		addRemoteCalls:  make([]*url.URL, 0),
+		addRemoteErrors: make(map[string]error),
 		ListRemoteUrls:  make([]*url.URL, 0),
 	}
 }
 
 // Mock implementation for testing with RepositorySource.
 type RepositorySource struct {
-	AddLocalCalls   []string
-	AddLocalErrors  map[string]error
-	AddRemoteCalls  []*url.URL
-	AddRemoteErrors map[string]error
+	addLocalCalls   []string
+	addLocalErrors  map[string]error
+	addRemoteCalls  []*url.URL
+	addRemoteErrors map[string]error
 	ListRemoteUrls  []*url.URL
 }
 
 /* Local repositories */
 
 func (source *RepositorySource) AddLocal(localPath string) error {
-	source.AddLocalCalls = append(source.AddLocalCalls, localPath)
-	return source.AddLocalErrors[localPath]
+	source.addLocalCalls = append(source.addLocalCalls, localPath)
+	return source.addLocalErrors[localPath]
 }
 
 func (source *RepositorySource) AddLocalExpected(expectedPaths ...string) {
 	ginkgo.GinkgoHelper()
-	Expect(source.AddLocalCalls).To(ConsistOf(expectedPaths))
+	Expect(source.addLocalCalls).To(ConsistOf(expectedPaths))
 }
 
 func (source *RepositorySource) AddLocalFails(path string, err error) {
-	source.AddLocalErrors[path] = err
+	source.addLocalErrors[path] = err
 }
 
 /* Remote repositories */
 
 func (source *RepositorySource) AddRemote(hostUrl *url.URL) error {
-	source.AddRemoteCalls = append(source.AddRemoteCalls, hostUrl)
-	return source.AddRemoteErrors[hostUrl.String()]
+	source.addRemoteCalls = append(source.addRemoteCalls, hostUrl)
+	return source.addRemoteErrors[hostUrl.String()]
 }
 
 func (source *RepositorySource) AddRemoteExpected(expectedHref string) {
@@ -58,7 +58,7 @@ func (source *RepositorySource) AddRemoteExpected(expectedHref string) {
 }
 
 func (source *RepositorySource) AddRemoteFails(faultyHref string, errorMsg string) {
-	source.AddRemoteErrors[faultyHref] = errors.New(errorMsg)
+	source.addRemoteErrors[faultyHref] = errors.New(errorMsg)
 }
 
 func (source *RepositorySource) AddRemoteNotExpected(unexpectedHref string) {
@@ -68,8 +68,8 @@ func (source *RepositorySource) AddRemoteNotExpected(unexpectedHref string) {
 }
 
 func (source *RepositorySource) addRemoteHrefs() []string {
-	actualHrefs := make([]string, len(source.AddRemoteCalls))
-	for i, call := range source.AddRemoteCalls {
+	actualHrefs := make([]string, len(source.addRemoteCalls))
+	for i, call := range source.addRemoteCalls {
 		actualHrefs[i] = call.String()
 	}
 

--- a/src/go/corerepositorymock/repository_source_mock.go
+++ b/src/go/corerepositorymock/repository_source_mock.go
@@ -12,6 +12,7 @@ import (
 func NewRepositorySource() *RepositorySource {
 	return &RepositorySource{
 		AddLocalCalls:   make([]string, 0),
+		AddLocalErrors:  make(map[string]error),
 		AddRemoteCalls:  make([]*url.URL, 0),
 		AddRemoteErrors: make(map[string]error),
 		ListRemoteUrls:  make([]*url.URL, 0),
@@ -21,6 +22,7 @@ func NewRepositorySource() *RepositorySource {
 // Mock implementation for testing with RepositorySource.
 type RepositorySource struct {
 	AddLocalCalls   []string
+	AddLocalErrors  map[string]error
 	AddRemoteCalls  []*url.URL
 	AddRemoteErrors map[string]error
 	ListRemoteUrls  []*url.URL
@@ -30,12 +32,16 @@ type RepositorySource struct {
 
 func (source *RepositorySource) AddLocal(localPath string) error {
 	source.AddLocalCalls = append(source.AddLocalCalls, localPath)
-	return nil
+	return source.AddLocalErrors[localPath]
 }
 
 func (source *RepositorySource) AddLocalExpected(expectedPaths ...string) {
 	ginkgo.GinkgoHelper()
 	Expect(source.AddLocalCalls).To(ConsistOf(expectedPaths))
+}
+
+func (source *RepositorySource) AddLocalFails(path string, err error) {
+	source.AddLocalErrors[path] = err
 }
 
 /* Remote repositories */

--- a/src/go/corerepositorymock/repository_source_mock.go
+++ b/src/go/corerepositorymock/repository_source_mock.go
@@ -28,6 +28,11 @@ type RepositorySource struct {
 
 /* Local repositories */
 
+func (source *RepositorySource) AddLocal(localPath string) error {
+	source.AddLocalCalls = append(source.AddLocalCalls, localPath)
+	return nil
+}
+
 func (source *RepositorySource) AddLocalExpected(expectedPaths ...string) {
 	ginkgo.GinkgoHelper()
 	Expect(source.AddLocalCalls).To(ConsistOf(expectedPaths))
@@ -47,7 +52,6 @@ func (source *RepositorySource) AddRemoteExpected(expectedHref string) {
 }
 
 func (source *RepositorySource) AddRemoteFails(faultyHref string, errorMsg string) {
-	ginkgo.GinkgoHelper()
 	source.AddRemoteErrors[faultyHref] = errors.New(errorMsg)
 }
 

--- a/src/go/corerepositorymock/repository_source_mock.go
+++ b/src/go/corerepositorymock/repository_source_mock.go
@@ -15,6 +15,7 @@ func NewRepositorySource() *RepositorySource {
 		addLocalErrors:  make(map[string]error),
 		addRemoteCalls:  make([]*url.URL, 0),
 		addRemoteErrors: make(map[string]error),
+		ListLocalPaths:  make([]string, 0),
 		ListRemoteUrls:  make([]*url.URL, 0),
 	}
 }
@@ -25,6 +26,7 @@ type RepositorySource struct {
 	addLocalErrors  map[string]error
 	addRemoteCalls  []*url.URL
 	addRemoteErrors map[string]error
+	ListLocalPaths  []string
 	ListRemoteUrls  []*url.URL
 }
 
@@ -42,6 +44,15 @@ func (source *RepositorySource) AddLocalExpected(expectedPaths ...string) {
 
 func (source *RepositorySource) AddLocalFails(path string, err error) {
 	source.addLocalErrors[path] = err
+}
+
+func (source *RepositorySource) ListLocal() (core.Repositories, error) {
+	repositories := make([]core.Repository, len(source.ListLocalPaths))
+	for i, localPath := range source.ListLocalPaths {
+		repositories[i] = core.LocalRepository(localPath)
+	}
+
+	return &core.RepositoriesArray{Repositories: repositories}, nil
 }
 
 /* Remote repositories */

--- a/src/go/cukefeature/cukefeature_test.go
+++ b/src/go/cukefeature/cukefeature_test.go
@@ -28,6 +28,7 @@ func TestFeatures(t *testing.T) {
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	step.AddLocalRepositorySteps(ctx)
 	step.AddMetaRepoSteps(ctx)
+	step.AddRemoteRepositorySteps(ctx)
 	step.AddRepositorySteps(ctx)
 	support.AddTo(ctx)
 }

--- a/src/go/cukefeature/cukefeature_test.go
+++ b/src/go/cukefeature/cukefeature_test.go
@@ -26,6 +26,7 @@ func TestFeatures(t *testing.T) {
 }
 
 func InitializeScenario(ctx *godog.ScenarioContext) {
+	step.AddLocalRepositorySteps(ctx)
 	step.AddMetaRepoSteps(ctx)
 	step.AddRepositorySteps(ctx)
 	support.AddTo(ctx)

--- a/src/go/cukefeature/repository.feature
+++ b/src/go/cukefeature/repository.feature
@@ -12,6 +12,14 @@ Feature: Repository
     Then that repository listing should be empty
 
   @LocalDir
+  #TODO KDK: Just implement the application command to register and the applicaiton query; leave CLI for another PR
+  Scenario: A Meta Repo remembers local repositories
+    Given I have initialized a new meta repo
+    And I have registered local repositories that have been cloned on the local filesystem
+    When I list local repositories in that meta repo
+    Then that repository listing should include those local repositories
+
+  @LocalDir
   Scenario: A Meta Repo remembers remote repositories
     Given I have initialized a new meta repo
     And I have registered remote repositories

--- a/src/go/cukefeature/repository.feature
+++ b/src/go/cukefeature/repository.feature
@@ -6,9 +6,9 @@ Feature: Repository
   @LocalDir
   Scenario: Meta Repos have no repositories when initialized
     Given I have initialized a new meta repo
-    When I list remote repositories in that meta repo
-    Then that repository listing should be empty
     When I list local repositories in that meta repo
+    Then that repository listing should be empty
+    When I list remote repositories in that meta repo
     Then that repository listing should be empty
 
   @LocalDir

--- a/src/go/cukefeature/repository.feature
+++ b/src/go/cukefeature/repository.feature
@@ -12,7 +12,6 @@ Feature: Repository
     Then that repository listing should be empty
 
   @LocalDir
-  #TODO KDK: Just implement the application command to register and the applicaiton query; leave CLI for another PR
   Scenario: A Meta Repo remembers local repositories
     Given Git repositories on the local filesystem
     And I have initialized a new meta repo

--- a/src/go/cukefeature/repository.feature
+++ b/src/go/cukefeature/repository.feature
@@ -14,8 +14,9 @@ Feature: Repository
   @LocalDir
   #TODO KDK: Just implement the application command to register and the applicaiton query; leave CLI for another PR
   Scenario: A Meta Repo remembers local repositories
-    Given I have initialized a new meta repo
-    And I have registered local repositories that have been cloned on the local filesystem
+    Given Git repositories on the local filesystem
+    And I have initialized a new meta repo
+    And I have registered those local repositories with a meta repo
     When I list local repositories in that meta repo
     Then that repository listing should include those local repositories
 

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -2,25 +2,57 @@ package cukestep
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/cucumber/godog"
-	core "github.com/kkrull/marmot/corerepository"
+	support "github.com/kkrull/marmot/cukesupport"
 )
 
 // State to clear between scenarios
-var thoseLocalRepositories core.Repositories
+var thoseLocalRepositories []*LocalRepository
+
+func InitLocalRepository(path string) (*LocalRepository, error) {
+	repo := &LocalRepository{path: path}
+	return repo, repo.Create()
+}
+
+type LocalRepository struct {
+	path string
+}
+
+func (localRepo *LocalRepository) Create() error {
+	return os.MkdirAll(localRepo.path, 0o777)
+}
+
+func (localRepo *LocalRepository) Delete() error {
+	return os.RemoveAll(localRepo.path)
+}
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
+	//TODO KDK: Delete directories containing local repositories, in a Before hook (not After)
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		//TODO KDK: Delete directories containing local repositories
+		var totalErr error = nil
+		for _, localRepo := range thoseLocalRepositories {
+			totalErr = errors.Join(totalErr, localRepo.Delete())
+		}
+
 		thoseLocalRepositories = nil
-		return ctx, err
+		return ctx, totalErr
 	})
 
 	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
 }
 
 func localGitRepositories() error {
-	return godog.ErrPending
+	if testDir, pathErr := support.TestDir(); pathErr != nil {
+		return pathErr
+	} else if repo, initErr := InitLocalRepository(filepath.Join(testDir, "empty-dir")); initErr != nil {
+		return initErr
+	} else {
+		thoseLocalRepositories = []*LocalRepository{repo}
+		return nil
+	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -26,7 +26,6 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Given(`^Git repositories on the local filesystem$`, createLocalGitRepositories)
 	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
 
-	ctx.When(`^I list local repositories in that meta repo$`, listLocal)
 	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
 }
 

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -1,0 +1,26 @@
+package cukestep
+
+import (
+	"context"
+
+	"github.com/cucumber/godog"
+	core "github.com/kkrull/marmot/corerepository"
+)
+
+// State to clear between scenarios
+var thoseLocalRepositories core.Repositories
+
+// Add step definitions related to repositories on the local filesystem.
+func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
+	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		//TODO KDK: Delete directories containing local repositories
+		thoseLocalRepositories = nil
+		return ctx, err
+	})
+
+	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
+}
+
+func localGitRepositories() error {
+	return godog.ErrPending
+}

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -12,15 +12,14 @@ var thoseLocalRepositories *support.LocalRepositories = support.NoLocalRepositor
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
+	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
 		if err != nil {
 			return ctx, err
+		} else {
+			return ctx, thoseLocalRepositories.DeleteAll()
 		}
-
-		return ctx, thoseLocalRepositories.DeleteAll()
 	})
-
-	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
 }
 
 func localGitRepositories() error {

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
@@ -32,7 +31,6 @@ func (localRepo *LocalRepository) Delete() error {
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
-	//TODO KDK: Delete directories containing local repositories, in a Before hook (not After)
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
 		var totalErr error = err
 		for _, localRepo := range thoseLocalRepositories {
@@ -47,10 +45,10 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 }
 
 func localGitRepositories() error {
-	if testDir, pathErr := support.TestDir(); pathErr != nil {
+	if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
 		return pathErr
-	} else if repo, initErr := InitLocalRepository(filepath.Join(testDir, "empty-dir")); initErr != nil {
-		return initErr
+	} else if repo, repoErr := InitLocalRepository(repoDir); repoErr != nil {
+		return repoErr
 	} else {
 		thoseLocalRepositories = []*LocalRepository{repo}
 		return nil

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -2,14 +2,16 @@ package cukestep
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
 )
 
-// State to clear between scenarios
+/* State */
+
 var thoseLocalRepositories *support.LocalRepositories = support.NoLocalRepositories()
+
+/* Configuration */
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
@@ -28,6 +30,8 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
 }
 
+/* Steps */
+
 func createLocalGitRepositories() error {
 	if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
 		return pathErr
@@ -35,19 +39,6 @@ func createLocalGitRepositories() error {
 		return repoErr
 	} else {
 		thoseLocalRepositories = support.SomeLocalRepositories(repo)
-		return nil
-	}
-}
-
-func listLocal() error {
-	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
-		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
-	} else if listRepositories, appErr := factory.NewListLocalRepositories(); appErr != nil {
-		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
-	} else if repositories, runErr := listRepositories(); runErr != nil {
-		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
-	} else {
-		thatListing = repositories
 		return nil
 	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -23,18 +23,27 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 		}
 	})
 
-	ctx.Given(`^Git repositories on the local filesystem$`, createLocalGitRepositories)
+	ctx.Given(`^Git repositories on the local filesystem$`, func() error {
+		return createLocalGitRepository("empty-dir")
+	})
+
+	// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
 	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
 
-	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
+	ctx.Then(`^that repository listing should include those local repositories$`, func() error {
+		if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
+			return pathErr
+		} else {
+			thatListingShouldHaveLocals(repoDir)
+			return nil
+		}
+	})
 }
 
 /* Steps */
 
-func createLocalGitRepositories() error {
-	if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
-		return pathErr
-	} else if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
+func createLocalGitRepository(repoDir string) error {
+	if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
 		return repoErr
 	} else {
 		thoseLocalRepositories = support.SomeLocalRepositories(repo)
@@ -43,10 +52,5 @@ func createLocalGitRepositories() error {
 }
 
 func registerLocal() error {
-	return godog.ErrPending
-}
-
-// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
-func thatListingShouldHaveLocals() error {
 	return godog.ErrPending
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -34,7 +34,7 @@ func (localRepo *LocalRepository) Delete() error {
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 	//TODO KDK: Delete directories containing local repositories, in a Before hook (not After)
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		var totalErr error = nil
+		var totalErr error = err
 		for _, localRepo := range thoseLocalRepositories {
 			totalErr = errors.Join(totalErr, localRepo.Delete())
 		}

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -1,8 +1,8 @@
 package cukestep
 
 import (
-	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
@@ -16,16 +16,12 @@ var thoseLocalRepositories *support.LocalRepositories = support.NoLocalRepositor
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
-	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		if err != nil {
-			return ctx, err
-		} else {
-			return ctx, thoseLocalRepositories.DeleteAll()
-		}
-	})
-
 	ctx.Given(`^Git repositories on the local filesystem$`, func() error {
-		return createLocalRepo("empty-dir")
+		if testDir, pathErr := support.TestDir(); pathErr != nil {
+			return pathErr
+		} else {
+			return createLocalRepo(filepath.Join(testDir, "empty-dir"))
+		}
 	})
 
 	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerThoseLocals)

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -2,25 +2,22 @@ package cukestep
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
 )
 
 // State to clear between scenarios
-var thoseLocalRepositories []*support.LocalRepository
+var thoseLocalRepositories *support.LocalRepositories = support.NoLocalRepositories()
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		var totalErr error = err
-		for _, localRepo := range thoseLocalRepositories {
-			totalErr = errors.Join(totalErr, localRepo.Delete())
+		if err != nil {
+			return ctx, err
 		}
 
-		thoseLocalRepositories = nil
-		return ctx, totalErr
+		return ctx, thoseLocalRepositories.DeleteAll()
 	})
 
 	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
@@ -32,7 +29,7 @@ func localGitRepositories() error {
 	} else if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
 		return repoErr
 	} else {
-		thoseLocalRepositories = []*support.LocalRepository{repo}
+		thoseLocalRepositories = support.SomeLocalRepositories(repo)
 		return nil
 	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -57,6 +57,6 @@ func registerThoseLocals() error {
 	} else if registerCmd, factoryErr := factory.NewRegisterLocalRepositories(); factoryErr != nil {
 		return fmt.Errorf("repository_steps: failed to initialize; %w", factoryErr)
 	} else {
-		return registerCmd.Run(thoseLocalRepositories.LocalPaths())
+		return registerCmd.Run(thoseLocalRepositories.LocalPaths()...)
 	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -2,6 +2,7 @@ package cukestep
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
@@ -24,11 +25,10 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 	})
 
 	ctx.Given(`^Git repositories on the local filesystem$`, func() error {
-		return createLocalGitRepository("empty-dir")
+		return createLocalRepo("empty-dir")
 	})
 
-	// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
-	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
+	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerThoseLocals)
 
 	ctx.Then(`^that repository listing should include those local repositories$`, func() error {
 		if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
@@ -42,7 +42,7 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 
 /* Steps */
 
-func createLocalGitRepository(repoDir string) error {
+func createLocalRepo(repoDir string) error {
 	if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
 		return repoErr
 	} else {
@@ -51,6 +51,12 @@ func createLocalGitRepository(repoDir string) error {
 	}
 }
 
-func registerLocal() error {
-	return godog.ErrPending
+func registerThoseLocals() error {
+	if factory, factoryErr := support.ThatCommandFactory(); factoryErr != nil {
+		return fmt.Errorf("repository_steps: failed to configure; %w", factoryErr)
+	} else if registerCmd, factoryErr := factory.NewRegisterLocalRepositories(); factoryErr != nil {
+		return fmt.Errorf("repository_steps: failed to initialize; %w", factoryErr)
+	} else {
+		return registerCmd.Run(thoseLocalRepositories.LocalPaths())
+	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -3,31 +3,13 @@ package cukestep
 import (
 	"context"
 	"errors"
-	"os"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
 )
 
 // State to clear between scenarios
-var thoseLocalRepositories []*LocalRepository
-
-func InitLocalRepository(path string) (*LocalRepository, error) {
-	repo := &LocalRepository{path: path}
-	return repo, repo.Create()
-}
-
-type LocalRepository struct {
-	path string
-}
-
-func (localRepo *LocalRepository) Create() error {
-	return os.MkdirAll(localRepo.path, 0o777)
-}
-
-func (localRepo *LocalRepository) Delete() error {
-	return os.RemoveAll(localRepo.path)
-}
+var thoseLocalRepositories []*support.LocalRepository
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
@@ -47,10 +29,10 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 func localGitRepositories() error {
 	if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
 		return pathErr
-	} else if repo, repoErr := InitLocalRepository(repoDir); repoErr != nil {
+	} else if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
 		return repoErr
 	} else {
-		thoseLocalRepositories = []*LocalRepository{repo}
+		thoseLocalRepositories = []*support.LocalRepository{repo}
 		return nil
 	}
 }

--- a/src/go/cukestep/local_repo_steps.go
+++ b/src/go/cukestep/local_repo_steps.go
@@ -2,6 +2,7 @@ package cukestep
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
@@ -12,7 +13,6 @@ var thoseLocalRepositories *support.LocalRepositories = support.NoLocalRepositor
 
 // Add step definitions related to repositories on the local filesystem.
 func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
-	ctx.Given(`^Git repositories on the local filesystem$`, localGitRepositories)
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
 		if err != nil {
 			return ctx, err
@@ -20,9 +20,15 @@ func AddLocalRepositorySteps(ctx *godog.ScenarioContext) {
 			return ctx, thoseLocalRepositories.DeleteAll()
 		}
 	})
+
+	ctx.Given(`^Git repositories on the local filesystem$`, createLocalGitRepositories)
+	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
+
+	ctx.When(`^I list local repositories in that meta repo$`, listLocal)
+	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
 }
 
-func localGitRepositories() error {
+func createLocalGitRepositories() error {
 	if repoDir, pathErr := support.TestSubDir("empty-dir"); pathErr != nil {
 		return pathErr
 	} else if repo, repoErr := support.InitLocalRepository(repoDir); repoErr != nil {
@@ -31,4 +37,26 @@ func localGitRepositories() error {
 		thoseLocalRepositories = support.SomeLocalRepositories(repo)
 		return nil
 	}
+}
+
+func listLocal() error {
+	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
+		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
+	} else if listRepositories, appErr := factory.NewListLocalRepositories(); appErr != nil {
+		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
+	} else if repositories, runErr := listRepositories(); runErr != nil {
+		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
+	} else {
+		thatListing = repositories
+		return nil
+	}
+}
+
+func registerLocal() error {
+	return godog.ErrPending
+}
+
+// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
+func thatListingShouldHaveLocals() error {
+	return godog.ErrPending
 }

--- a/src/go/cukestep/meta_repo_steps.go
+++ b/src/go/cukestep/meta_repo_steps.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/cucumber/godog"
 	support "github.com/kkrull/marmot/cukesupport"
-	"github.com/kkrull/marmot/svcfs"
-	"github.com/kkrull/marmot/use"
 )
 
 // Add step definitions to manage the life cycle of a meta repo.
@@ -18,7 +16,7 @@ func AddMetaRepoSteps(ctx *godog.ScenarioContext) {
 /* Steps */
 
 func initNewMetaRepo(ctx *godog.ScenarioContext) error {
-	factory := use.NewCommandFactory().WithMetaDataAdmin(svcfs.NewJsonMetaRepoAdmin("42"))
+	factory := support.ThatCommandFactoryS("42")
 	if initCmd, factoryErr := factory.NewInitMetaRepo(); factoryErr != nil {
 		return fmt.Errorf("meta_repo_steps: failed to initialize; %w", factoryErr)
 	} else if thatMetaRepo, initErr := support.InitThatMetaRepo(ctx); initErr != nil {

--- a/src/go/cukestep/remote_repo_steps.go
+++ b/src/go/cukestep/remote_repo_steps.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+/* Configuration */
+
 // Add step definitions related to remote repositories.
 func AddRemoteRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Given(`^I have registered remote repositories$`, registerRemote)
@@ -16,18 +18,7 @@ func AddRemoteRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Then(`^that repository listing should include those remote repositories$`, thatListingShouldHaveRemotes)
 }
 
-func listRemote() error {
-	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
-		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
-	} else if listRepositories, appErr := factory.NewListRemoteRepositories(); appErr != nil {
-		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
-	} else if repositories, runErr := listRepositories(); runErr != nil {
-		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
-	} else {
-		thatListing = repositories
-		return nil
-	}
-}
+/* Steps */
 
 func registerRemote() error {
 	if remoteUrl, parseErr := url.Parse("https://github.com/actions/checkout"); parseErr != nil {
@@ -44,7 +35,7 @@ func registerRemote() error {
 }
 
 func thatListingShouldHaveRemotes() error {
-	remoteUrls := thatListing.RemoteUrls()
+	remoteUrls := thatListing().RemoteUrls()
 	remoteHrefs := make([]string, len(remoteUrls))
 	for i, remoteUrl := range remoteUrls {
 		remoteHrefs[i] = remoteUrl.String()

--- a/src/go/cukestep/remote_repo_steps.go
+++ b/src/go/cukestep/remote_repo_steps.go
@@ -1,71 +1,20 @@
 package cukestep
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 
 	"github.com/cucumber/godog"
-	core "github.com/kkrull/marmot/corerepository"
 	support "github.com/kkrull/marmot/cukesupport"
 	. "github.com/onsi/gomega"
 )
 
-// State to clear between scenarios
-var thatListing core.Repositories
-
-// Add step definitions related to repositories.
-func AddRepositorySteps(ctx *godog.ScenarioContext) {
-	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		thatListing = nil
-		return ctx, err
-	})
-
-	//All kinds of repositories
-	ctx.Then(`^that repository listing should be empty$`, thatListingShouldBeEmpty)
-
-	//Local repositories
-	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
-	ctx.When(`^I list local repositories in that meta repo$`, listLocal)
-	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
-
-	//Remote repositories
+// Add step definitions related to remote repositories.
+func AddRemoteRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Given(`^I have registered remote repositories$`, registerRemote)
 	ctx.When(`^I list remote repositories in that meta repo$`, listRemote)
 	ctx.Then(`^that repository listing should include those remote repositories$`, thatListingShouldHaveRemotes)
 }
-
-/* All kinds of repositories */
-
-func thatListingShouldBeEmpty() {
-	Expect(thatListing.Count()).To(Equal(0))
-}
-
-/* Local repositories */
-
-func listLocal() error {
-	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
-		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
-	} else if listRepositories, appErr := factory.NewListLocalRepositories(); appErr != nil {
-		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
-	} else if repositories, runErr := listRepositories(); runErr != nil {
-		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
-	} else {
-		thatListing = repositories
-		return nil
-	}
-}
-
-func registerLocal() error {
-	return godog.ErrPending
-}
-
-// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
-func thatListingShouldHaveLocals() error {
-	return godog.ErrPending
-}
-
-/* Remote repositories */
 
 func listRemote() error {
 	if factory, configErr := support.ThatQueryFactory(); configErr != nil {

--- a/src/go/cukestep/repository_listing_steps.go
+++ b/src/go/cukestep/repository_listing_steps.go
@@ -1,0 +1,26 @@
+package cukestep
+
+import (
+	"context"
+
+	"github.com/cucumber/godog"
+	core "github.com/kkrull/marmot/corerepository"
+	. "github.com/onsi/gomega"
+)
+
+// State to clear between scenarios
+var thatListing core.Repositories
+
+// Add step definitions related to listing repositories.
+func AddRepositorySteps(ctx *godog.ScenarioContext) {
+	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		thatListing = nil
+		return ctx, err
+	})
+
+	ctx.Then(`^that repository listing should be empty$`, thatListingShouldBeEmpty)
+}
+
+func thatListingShouldBeEmpty() {
+	Expect(thatListing.Count()).To(Equal(0))
+}

--- a/src/go/cukestep/repository_listing_steps.go
+++ b/src/go/cukestep/repository_listing_steps.go
@@ -70,8 +70,8 @@ func thatListingShouldBeEmpty() {
 	Expect(thatListing().Count()).To(Equal(0))
 }
 
-func thatListingShouldHaveLocals(expectedPaths ...string) error {
-	return godog.ErrPending
+func thatListingShouldHaveLocals(expectedPaths ...string) {
+	Expect(thatListing().LocalPaths()).To(ConsistOf(expectedPaths))
 }
 
 func thatListingShouldHaveRemotes(expectedHrefs ...string) {

--- a/src/go/cukestep/repository_listing_steps.go
+++ b/src/go/cukestep/repository_listing_steps.go
@@ -2,25 +2,68 @@ package cukestep
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cucumber/godog"
 	core "github.com/kkrull/marmot/corerepository"
+	support "github.com/kkrull/marmot/cukesupport"
 	. "github.com/onsi/gomega"
 )
 
-// State to clear between scenarios
-var thatListing core.Repositories
+/* Configuration */
 
 // Add step definitions related to listing repositories.
 func AddRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
-		thatListing = nil
+		_thatListing = nil
 		return ctx, err
 	})
 
 	ctx.Then(`^that repository listing should be empty$`, thatListingShouldBeEmpty)
 }
 
+/* State */
+
+var _thatListing core.Repositories
+
+// Store the most recent listing
+func setThatListing(listing core.Repositories) {
+	_thatListing = listing
+}
+
+// Whichever repositories were returned from the most recent listing, if any.
+func thatListing() core.Repositories {
+	return _thatListing
+}
+
+/* Use */
+
+func listLocal() error {
+	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
+		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
+	} else if listRepositories, appErr := factory.NewListLocalRepositories(); appErr != nil {
+		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
+	} else if repositories, runErr := listRepositories(); runErr != nil {
+		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
+	} else {
+		setThatListing(repositories)
+		return nil
+	}
+}
+
+func listRemote() error {
+	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
+		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
+	} else if listRepositories, appErr := factory.NewListRemoteRepositories(); appErr != nil {
+		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
+	} else if repositories, runErr := listRepositories(); runErr != nil {
+		return fmt.Errorf("repository_steps: failed to run query; %w", runErr)
+	} else {
+		setThatListing(repositories)
+		return nil
+	}
+}
+
 func thatListingShouldBeEmpty() {
-	Expect(thatListing.Count()).To(Equal(0))
+	Expect(thatListing().Count()).To(Equal(0))
 }

--- a/src/go/cukestep/repository_listing_steps.go
+++ b/src/go/cukestep/repository_listing_steps.go
@@ -70,6 +70,10 @@ func thatListingShouldBeEmpty() {
 	Expect(thatListing().Count()).To(Equal(0))
 }
 
+func thatListingShouldHaveLocals(expectedPaths ...string) error {
+	return godog.ErrPending
+}
+
 func thatListingShouldHaveRemotes(expectedHrefs ...string) {
 	remoteUrls := thatListing().RemoteUrls()
 	remoteHrefs := make([]string, len(remoteUrls))

--- a/src/go/cukestep/repository_listing_steps.go
+++ b/src/go/cukestep/repository_listing_steps.go
@@ -20,6 +20,8 @@ func AddRepositorySteps(ctx *godog.ScenarioContext) {
 	})
 
 	ctx.Then(`^that repository listing should be empty$`, thatListingShouldBeEmpty)
+	ctx.When(`^I list local repositories in that meta repo$`, listLocal)
+	ctx.When(`^I list remote repositories in that meta repo$`, listRemote)
 }
 
 /* State */
@@ -66,4 +68,14 @@ func listRemote() error {
 
 func thatListingShouldBeEmpty() {
 	Expect(thatListing().Count()).To(Equal(0))
+}
+
+func thatListingShouldHaveRemotes(expectedHrefs ...string) {
+	remoteUrls := thatListing().RemoteUrls()
+	remoteHrefs := make([]string, len(remoteUrls))
+	for i, remoteUrl := range remoteUrls {
+		remoteHrefs[i] = remoteUrl.String()
+	}
+
+	Expect(remoteHrefs).To(ConsistOf(expectedHrefs))
 }

--- a/src/go/cukestep/repository_steps.go
+++ b/src/go/cukestep/repository_steps.go
@@ -25,7 +25,9 @@ func AddRepositorySteps(ctx *godog.ScenarioContext) {
 	ctx.Then(`^that repository listing should be empty$`, thatListingShouldBeEmpty)
 
 	//Local repositories
+	ctx.Given(`^I have registered those local repositories with a meta repo$`, registerLocal)
 	ctx.When(`^I list local repositories in that meta repo$`, listLocal)
+	ctx.Then(`^that repository listing should include those local repositories$`, thatListingShouldHaveLocals)
 
 	//Remote repositories
 	ctx.Given(`^I have registered remote repositories$`, registerRemote)
@@ -52,6 +54,14 @@ func listLocal() error {
 		thatListing = repositories
 		return nil
 	}
+}
+
+func registerLocal() error {
+	return godog.ErrPending
+}
+
+func thatListingShouldHaveLocals() error {
+	return godog.ErrPending
 }
 
 /* Remote repositories */

--- a/src/go/cukestep/repository_steps.go
+++ b/src/go/cukestep/repository_steps.go
@@ -60,6 +60,7 @@ func registerLocal() error {
 	return godog.ErrPending
 }
 
+// TODO KDK: Just implement the application command to register and the application query; leave CLI for another PR
 func thatListingShouldHaveLocals() error {
 	return godog.ErrPending
 }

--- a/src/go/cukestep/repository_steps.go
+++ b/src/go/cukestep/repository_steps.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cucumber/godog"
 	core "github.com/kkrull/marmot/corerepository"
 	support "github.com/kkrull/marmot/cukesupport"
-	"github.com/kkrull/marmot/svcfs"
-	"github.com/kkrull/marmot/use"
 	. "github.com/onsi/gomega"
 )
 
@@ -44,7 +42,7 @@ func thatListingShouldBeEmpty() {
 /* Local repositories */
 
 func listLocal() error {
-	if factory, configErr := queryFactoryForThatMetaRepo(); configErr != nil {
+	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
 		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
 	} else if listRepositories, appErr := factory.NewListLocalRepositories(); appErr != nil {
 		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
@@ -59,7 +57,7 @@ func listLocal() error {
 /* Remote repositories */
 
 func listRemote() error {
-	if factory, configErr := queryFactoryForThatMetaRepo(); configErr != nil {
+	if factory, configErr := support.ThatQueryFactory(); configErr != nil {
 		return fmt.Errorf("repository_steps: failed to configure; %w", configErr)
 	} else if listRepositories, appErr := factory.NewListRemoteRepositories(); appErr != nil {
 		return fmt.Errorf("repository_steps: failed to initialize; %w", appErr)
@@ -74,7 +72,7 @@ func listRemote() error {
 func registerRemote() error {
 	if remoteUrl, parseErr := url.Parse("https://github.com/actions/checkout"); parseErr != nil {
 		return parseErr
-	} else if factory, factoryErr := commandFactoryForThatMetaRepo(); factoryErr != nil {
+	} else if factory, factoryErr := support.ThatCommandFactory(); factoryErr != nil {
 		return fmt.Errorf("repository_steps: failed to configure; %w", factoryErr)
 	} else if registerCmd, factoryErr := factory.NewRegisterRemoteRepositories(); factoryErr != nil {
 		return fmt.Errorf("repository_steps: failed to initialize; %w", factoryErr)
@@ -94,24 +92,4 @@ func thatListingShouldHaveRemotes() error {
 
 	Expect(remoteHrefs).To(ConsistOf("https://github.com/actions/checkout"))
 	return nil
-}
-
-/* Configuration */
-
-func commandFactoryForThatMetaRepo() (use.CommandFactory, error) {
-	if metaRepoPath, pathErr := support.ThatMetaRepo(); pathErr != nil {
-		return nil, pathErr
-	} else {
-		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
-		return use.NewCommandFactory().WithRepositorySource(jsonMetaRepo), nil
-	}
-}
-
-func queryFactoryForThatMetaRepo() (use.QueryFactory, error) {
-	if metaRepoPath, pathErr := support.ThatMetaRepo(); pathErr != nil {
-		return nil, pathErr
-	} else {
-		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
-		return use.NewQueryFactory().WithRepositorySource(jsonMetaRepo), nil
-	}
 }

--- a/src/go/cukesupport/app_helper.go
+++ b/src/go/cukesupport/app_helper.go
@@ -1,0 +1,32 @@
+package cukesupport
+
+import (
+	"github.com/kkrull/marmot/svcfs"
+	"github.com/kkrull/marmot/use"
+)
+
+// Create a factory for application commands on the current meta repo.
+func ThatCommandFactory() (use.CommandFactory, error) {
+	if metaRepoPath, pathErr := ThatMetaRepo(); pathErr != nil {
+		return nil, pathErr
+	} else {
+		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
+		return use.NewCommandFactory().WithRepositorySource(jsonMetaRepo), nil
+	}
+}
+
+// Create a CommandFactory to initialize a meta repo with the specified version.
+func ThatCommandFactoryS(version string) use.CommandFactory {
+	return use.NewCommandFactory().
+		WithMetaDataAdmin(svcfs.NewJsonMetaRepoAdmin(version))
+}
+
+// Create a factory to run queries on the current meta repo.
+func ThatQueryFactory() (use.QueryFactory, error) {
+	if metaRepoPath, pathErr := ThatMetaRepo(); pathErr != nil {
+		return nil, pathErr
+	} else {
+		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
+		return use.NewQueryFactory().WithRepositorySource(jsonMetaRepo), nil
+	}
+}

--- a/src/go/cukesupport/local_dir.go
+++ b/src/go/cukesupport/local_dir.go
@@ -19,14 +19,22 @@ const TagName = "@LocalDir"
 
 var testDir string
 
-// A temporary directory created for the current scenario, which will be deleted later.  Tag
-// scenarios or features with the tag in `TagName` to get started.
+// A temporary directory for scenarios tagged with `TagName`, to automatically delete afterwards.
 func TestDir() (string, error) {
 	if testDir == "" {
 		return "", fmt.Errorf("[%s] not initialized", TagName)
 	}
 
 	return testDir, nil
+}
+
+// The named subdirectory inside this scenario's temporary directory (which is deleted afterwards).
+func TestSubDir(subdir string) (string, error) {
+	if testDir == "" {
+		return "", fmt.Errorf("[%s] not initialized", TagName)
+	}
+
+	return filepath.Join(testDir, subdir), nil
 }
 
 func setTestDir(path string) {

--- a/src/go/cukesupport/local_repo.go
+++ b/src/go/cukesupport/local_repo.go
@@ -1,0 +1,24 @@
+package cukesupport
+
+import "os"
+
+// Initialize a Git repository at the specified path on the local filesystem.
+func InitLocalRepository(path string) (*LocalRepository, error) {
+	repo := &LocalRepository{path: path}
+	return repo, repo.Create()
+}
+
+// A Git repository on the local filesystem.
+type LocalRepository struct {
+	path string
+}
+
+// Create the Git repository.
+func (localRepo *LocalRepository) Create() error {
+	return os.MkdirAll(localRepo.path, 0o777)
+}
+
+// Delete the directory containing the Git repository.
+func (localRepo *LocalRepository) Delete() error {
+	return os.RemoveAll(localRepo.path)
+}

--- a/src/go/cukesupport/local_repo.go
+++ b/src/go/cukesupport/local_repo.go
@@ -1,6 +1,9 @@
 package cukesupport
 
-import "os"
+import (
+	"errors"
+	"os"
+)
 
 // Initialize a Git repository at the specified path on the local filesystem.
 func InitLocalRepository(path string) (*LocalRepository, error) {
@@ -21,4 +24,28 @@ func (localRepo *LocalRepository) Create() error {
 // Delete the directory containing the Git repository.
 func (localRepo *LocalRepository) Delete() error {
 	return os.RemoveAll(localRepo.path)
+}
+
+/* Container */
+
+func NoLocalRepositories() *LocalRepositories {
+	return &LocalRepositories{repositories: make([]*LocalRepository, 0)}
+}
+
+func SomeLocalRepositories(repositories ...*LocalRepository) *LocalRepositories {
+	return &LocalRepositories{repositories: repositories}
+}
+
+type LocalRepositories struct {
+	repositories []*LocalRepository
+}
+
+// Exhaustively try to delete each local repository, joining any errors from individual attempts.
+func (container *LocalRepositories) DeleteAll() error {
+	var totalErr error = nil
+	for _, localRepo := range container.repositories {
+		totalErr = errors.Join(totalErr, localRepo.Delete())
+	}
+
+	return totalErr
 }

--- a/src/go/cukesupport/local_repo.go
+++ b/src/go/cukesupport/local_repo.go
@@ -28,10 +28,12 @@ func (localRepo *LocalRepository) Delete() error {
 
 /* Container */
 
+// Create an empty container for local repositories.
 func NoLocalRepositories() *LocalRepositories {
 	return &LocalRepositories{repositories: make([]*LocalRepository, 0)}
 }
 
+// Create a container for local repositories.
 func SomeLocalRepositories(repositories ...*LocalRepository) *LocalRepositories {
 	return &LocalRepositories{repositories: repositories}
 }

--- a/src/go/cukesupport/local_repo.go
+++ b/src/go/cukesupport/local_repo.go
@@ -3,12 +3,17 @@ package cukesupport
 import (
 	"errors"
 	"os"
+	"path/filepath"
 )
 
 // Initialize a Git repository at the specified path on the local filesystem.
 func InitLocalRepository(path string) (*LocalRepository, error) {
-	repo := &LocalRepository{path: path}
-	return repo, repo.Create()
+	if absPath, pathErr := filepath.Abs(path); pathErr != nil {
+		return nil, pathErr
+	} else {
+		repo := &LocalRepository{path: absPath}
+		return repo, repo.Create()
+	}
 }
 
 // A Git repository on the local filesystem.
@@ -50,4 +55,14 @@ func (container *LocalRepositories) DeleteAll() error {
 	}
 
 	return totalErr
+}
+
+// Paths on the local filesystem, to each repository.
+func (container *LocalRepositories) LocalPaths() []string {
+	localPaths := make([]string, len(container.repositories))
+	for i, repository := range container.repositories {
+		localPaths[i] = repository.path
+	}
+
+	return localPaths
 }

--- a/src/go/svcfs/json_meta_repo.go
+++ b/src/go/svcfs/json_meta_repo.go
@@ -22,6 +22,10 @@ func (repo *JsonMetaRepo) AddLocal(localPath string) error {
 	return nil
 }
 
+func (repo *JsonMetaRepo) ListLocal() (core.Repositories, error) {
+	return core.NoRepositories(), nil
+}
+
 /* Remote repositories */
 
 func (repo *JsonMetaRepo) AddRemote(hostUrl *url.URL) error {

--- a/src/go/svcfs/json_meta_repo.go
+++ b/src/go/svcfs/json_meta_repo.go
@@ -16,7 +16,13 @@ type JsonMetaRepo struct {
 	metaDataFile string
 }
 
-/* RepositorySource */
+/* Local repositories */
+
+func (repo *JsonMetaRepo) AddLocal(localPath string) error {
+	return nil
+}
+
+/* Remote repositories */
 
 func (repo *JsonMetaRepo) AddRemote(hostUrl *url.URL) error {
 	var rootObject *rootObjectData

--- a/src/go/svcfs/json_meta_repo.go
+++ b/src/go/svcfs/json_meta_repo.go
@@ -19,11 +19,28 @@ type JsonMetaRepo struct {
 /* Local repositories */
 
 func (repo *JsonMetaRepo) AddLocal(localPath string) error {
-	return nil
+	var rootObject *rootObjectData
+	rootObject, readErr := ReadMetaRepoFile(repo.metaDataFile)
+	if readErr != nil {
+		return fmt.Errorf("failed to read file %s; %w", repo.metaDataFile, readErr)
+	}
+
+	rootObject.MetaRepo.AppendLocalRepository(localRepositoryData{Path: localPath})
+	if writeErr := rootObject.WriteTo(repo.metaDataFile); writeErr != nil {
+		return fmt.Errorf("failed to write file %s; %w", repo.metaDataFile, writeErr)
+	} else {
+		return nil
+	}
 }
 
 func (repo *JsonMetaRepo) ListLocal() (core.Repositories, error) {
-	return core.NoRepositories(), nil
+	if rootObject, readErr := ReadMetaRepoFile(repo.metaDataFile); readErr != nil {
+		return nil, fmt.Errorf("failed to read file %s; %w", repo.metaDataFile, readErr)
+	} else if repositories, mapErr := rootObject.MetaRepo.MapLocalRepositories(); mapErr != nil {
+		return nil, fmt.Errorf("failed to map to core model; %w", mapErr)
+	} else {
+		return repositories, nil
+	}
 }
 
 /* Remote repositories */

--- a/src/go/svcfs/json_meta_repo_test.go
+++ b/src/go/svcfs/json_meta_repo_test.go
@@ -26,21 +26,16 @@ var _ = Describe("JsonMetaDataRepo", func() {
 		DeferCleanup(os.RemoveAll, testFsRoot)
 	})
 
-	It("#AddLocal exists", func() {
-		admin = jsonMetaRepoAdmin(nil)
-		subject = svcfs.NewJsonMetaRepo(metaRepoPath)
-		Expect(admin.Create(metaRepoPath)).To(Succeed())
-
-		Expect(subject.AddLocal("/path/to/repo")).To(Succeed())
-	})
-
-	It("#ListLocal exists", Pending, func() {})
-
 	Context("when no repositories have been registered", func() {
 		BeforeEach(func() {
 			admin = jsonMetaRepoAdmin(nil)
 			subject = svcfs.NewJsonMetaRepo(metaRepoPath)
 			Expect(admin.Create(metaRepoPath)).To(Succeed())
+		})
+
+		It("#ListLocal returns empty", func() {
+			repositories := expect.NoError(subject.ListLocal())
+			Expect(repositories.Count()).To(Equal(0))
 		})
 
 		It("#ListRemote returns empty", func() {

--- a/src/go/svcfs/json_meta_repo_test.go
+++ b/src/go/svcfs/json_meta_repo_test.go
@@ -26,6 +26,16 @@ var _ = Describe("JsonMetaDataRepo", func() {
 		DeferCleanup(os.RemoveAll, testFsRoot)
 	})
 
+	It("#AddLocal exists", func() {
+		admin = jsonMetaRepoAdmin(nil)
+		subject = svcfs.NewJsonMetaRepo(metaRepoPath)
+		Expect(admin.Create(metaRepoPath)).To(Succeed())
+
+		Expect(subject.AddLocal("/path/to/repo")).To(Succeed())
+	})
+
+	It("#ListLocal exists", Pending, func() {})
+
 	Context("when no repositories have been registered", func() {
 		BeforeEach(func() {
 			admin = jsonMetaRepoAdmin(nil)

--- a/src/go/svcfs/json_meta_repo_test.go
+++ b/src/go/svcfs/json_meta_repo_test.go
@@ -44,6 +44,21 @@ var _ = Describe("JsonMetaDataRepo", func() {
 		})
 	})
 
+	Context("when local repositories have been registered", func() {
+		BeforeEach(func() {
+			admin = jsonMetaRepoAdmin(nil)
+			subject = svcfs.NewJsonMetaRepo(metaRepoPath)
+			Expect(admin.Create(metaRepoPath)).To(Succeed())
+
+			Expect(subject.AddLocal("/path/to/one")).To(Succeed())
+		})
+
+		It("#ListLocal includes each registered local repository", func() {
+			returned := expect.NoError(subject.ListLocal())
+			Expect(returned.LocalPaths()).To(ConsistOf("/path/to/one"))
+		})
+	})
+
 	Context("when remote repositories have been registered", func() {
 		BeforeEach(func() {
 			admin = jsonMetaRepoAdmin(nil)
@@ -51,9 +66,6 @@ var _ = Describe("JsonMetaDataRepo", func() {
 			Expect(admin.Create(metaRepoPath)).To(Succeed())
 
 			Expect(subject.AddRemote(testdata.NewURL("https://github.com/me/a"))).To(Succeed())
-			listOne := expect.NoError(subject.ListRemote())
-			Expect(listOne.RemoteHrefs()).To(ConsistOf("https://github.com/me/a"))
-
 			Expect(subject.AddRemote(testdata.NewURL("https://github.com/me/b"))).To(Succeed())
 		})
 

--- a/src/go/svcfs/meta_repo_file.go
+++ b/src/go/svcfs/meta_repo_file.go
@@ -21,7 +21,12 @@ type rootObjectData struct {
 }
 
 type metaRepoData struct {
+	LocalRepositories  []localRepositoryData  `json:"local_repositories"`
 	RemoteRepositories []remoteRepositoryData `json:"remote_repositories"`
+}
+
+type localRepositoryData struct {
+	Path string `json:"path"`
 }
 
 type remoteRepositoryData struct {
@@ -29,6 +34,10 @@ type remoteRepositoryData struct {
 }
 
 /* Updates */
+
+func (metaRepo *metaRepoData) AppendLocalRepository(localRepository localRepositoryData) {
+	metaRepo.LocalRepositories = append(metaRepo.LocalRepositories, localRepository)
+}
 
 func (metaRepo *metaRepoData) AppendRemoteRepository(remoteRepository remoteRepositoryData) {
 	metaRepo.RemoteRepositories = append(metaRepo.RemoteRepositories, remoteRepository)

--- a/src/go/svcfs/meta_repo_file_mapping.go
+++ b/src/go/svcfs/meta_repo_file_mapping.go
@@ -6,19 +6,38 @@ import (
 	"github.com/kkrull/marmot/corerepository"
 )
 
-func (metaRepo *metaRepoData) MapRemoteRepositories() (corerepository.Repositories, error) {
-	repositories := make([]corerepository.Repository, len(metaRepo.RemoteRepositories))
-	for i, remoteRepository := range metaRepo.RemoteRepositories {
-		if repository, mapErr := remoteRepository.ToCoreRepository(); mapErr != nil {
+/* Local repositories */
+
+func (metaRepo *metaRepoData) MapLocalRepositories() (corerepository.Repositories, error) {
+	repositories := make([]corerepository.Repository, len(metaRepo.LocalRepositories))
+	for i, localRepositoryData := range metaRepo.LocalRepositories {
+		if repository, mapErr := localRepositoryData.ToCoreRepository(); mapErr != nil {
 			return nil, mapErr
 		} else {
 			repositories[i] = repository
 		}
 	}
 
-	return &corerepository.RepositoriesArray{
-		Repositories: repositories,
-	}, nil
+	return corerepository.SomeRepositories(repositories), nil
+}
+
+func (localRepo *localRepositoryData) ToCoreRepository() (corerepository.Repository, error) {
+	return corerepository.LocalRepository(localRepo.Path), nil
+}
+
+/* Remote repositories */
+
+func (metaRepo *metaRepoData) MapRemoteRepositories() (corerepository.Repositories, error) {
+	repositories := make([]corerepository.Repository, len(metaRepo.RemoteRepositories))
+	for i, remoteRepositoryData := range metaRepo.RemoteRepositories {
+		if repository, mapErr := remoteRepositoryData.ToCoreRepository(); mapErr != nil {
+			return nil, mapErr
+		} else {
+			repositories[i] = repository
+		}
+	}
+
+	return corerepository.SomeRepositories(repositories), nil
 }
 
 func (remoteRepo *remoteRepositoryData) ToCoreRepository() (corerepository.Repository, error) {

--- a/src/go/use/command_factory.go
+++ b/src/go/use/command_factory.go
@@ -16,6 +16,7 @@ func NewCommandFactory() *cmdFactory {
 // Constructs application commands and queries with configurable services.
 type CommandFactory interface {
 	NewInitMetaRepo() (*metarepo.InitCommand, error)
+	NewRegisterLocalRepositories() (*repository.RegisterLocalRepositoriesCommand, error)
 	NewRegisterRemoteRepositories() (*repository.RegisterRemoteRepositoriesCommand, error)
 }
 
@@ -52,7 +53,17 @@ func (factory *cmdFactory) NewInitMetaRepo() (*metarepo.InitCommand, error) {
 	}
 }
 
-/* Remote repositories */
+/* Repositories */
+
+func (factory *cmdFactory) NewRegisterLocalRepositories() (
+	*repository.RegisterLocalRepositoriesCommand, error,
+) {
+	if repositorySource, err := factory.repositorySource(); err != nil {
+		return nil, err
+	} else {
+		return &repository.RegisterLocalRepositoriesCommand{Source: repositorySource}, nil
+	}
+}
 
 func (factory *cmdFactory) NewRegisterRemoteRepositories() (
 	*repository.RegisterRemoteRepositoriesCommand, error,

--- a/src/go/use/query_factory.go
+++ b/src/go/use/query_factory.go
@@ -36,13 +36,11 @@ func (factory *queryFactory) WithRepositorySource(source corerepository.Reposito
 /* Repositories */
 
 func (factory *queryFactory) NewListLocalRepositories() (userepository.ListRemoteRepositoriesQuery, error) {
-	// TODO KDK: Awaiting a way to register local repositories
-	localRepositoriesAlwaysEmpty := func() (corerepository.Repositories, error) {
-		repositories := make([]corerepository.Repository, 0)
-		return &corerepository.RepositoriesArray{Repositories: repositories}, nil
+	if repositorySource, err := factory.repositorySource(); err != nil {
+		return nil, err
+	} else {
+		return repositorySource.ListLocal, nil
 	}
-
-	return localRepositoriesAlwaysEmpty, nil
 }
 
 func (factory *queryFactory) NewListRemoteRepositories() (userepository.ListRemoteRepositoriesQuery, error) {

--- a/src/go/use/query_factory.go
+++ b/src/go/use/query_factory.go
@@ -36,7 +36,7 @@ func (factory *queryFactory) WithRepositorySource(source corerepository.Reposito
 /* Repositories */
 
 func (factory *queryFactory) NewListLocalRepositories() (userepository.ListRemoteRepositoriesQuery, error) {
-	//Awaiting a way to register local repositories
+	// TODO KDK: Awaiting a way to register local repositories
 	localRepositoriesAlwaysEmpty := func() (corerepository.Repositories, error) {
 		repositories := make([]corerepository.Repository, 0)
 		return &corerepository.RepositoriesArray{Repositories: repositories}, nil

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -4,10 +4,15 @@ import (
 	core "github.com/kkrull/marmot/corerepository"
 )
 
+// Registers Git repositories with the meta repo, based upon their paths on the local filesystem.
 type RegisterLocalRepositoriesCommand struct {
 	Source core.RepositorySource
 }
 
 func (cmd *RegisterLocalRepositoriesCommand) Run(localPaths ...string) error {
+	for _, localPath := range localPaths {
+		cmd.Source.AddLocal(localPath)
+	}
+
 	return nil
 }

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -1,6 +1,8 @@
 package userepository
 
 import (
+	"fmt"
+
 	core "github.com/kkrull/marmot/corerepository"
 )
 
@@ -11,7 +13,9 @@ type RegisterLocalRepositoriesCommand struct {
 
 func (cmd *RegisterLocalRepositoriesCommand) Run(localPaths ...string) error {
 	for _, localPath := range localPaths {
-		cmd.Source.AddLocal(localPath)
+		if addErr := cmd.Source.AddLocal(localPath); addErr != nil {
+			return fmt.Errorf("failed to add local repository %s: %w", localPath, addErr)
+		}
 	}
 
 	return nil

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -1,8 +1,6 @@
 package userepository
 
 import (
-	"errors"
-
 	core "github.com/kkrull/marmot/corerepository"
 )
 
@@ -11,5 +9,5 @@ type RegisterLocalRepositoriesCommand struct {
 }
 
 func (cmd *RegisterLocalRepositoriesCommand) Run(localPaths ...string) error {
-	return errors.ErrUnsupported
+	return nil
 }

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -1,7 +1,15 @@
 package userepository
 
-import core "github.com/kkrull/marmot/corerepository"
+import (
+	"errors"
+
+	core "github.com/kkrull/marmot/corerepository"
+)
 
 type RegisterLocalRepositoriesCommand struct {
 	Source core.RepositorySource
+}
+
+func (cmd *RegisterLocalRepositoriesCommand) Run(localPaths ...string) error {
+	return errors.ErrUnsupported
 }

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -1,0 +1,7 @@
+package userepository
+
+import core "github.com/kkrull/marmot/corerepository"
+
+type RegisterLocalRepositoriesCommand struct {
+	Source core.RepositorySource
+}

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -24,8 +24,8 @@ var _ = Describe("RegisterLocalRepositoriesCommand", func() {
 
 	Describe("#Run", func() {
 		It("passes local paths to the repository source", func() {
-			subject.Run("/path/to/repo")
-			source.AddLocalExpected("/path/to/repo")
+			subject.Run("/path/to/a", "/path/to/b")
+			source.AddLocalExpected("/path/to/a", "/path/to/b")
 		})
 
 		It("returns nil when everything succeeds", func() {

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -1,0 +1,27 @@
+package userepository_test
+
+import (
+	mock "github.com/kkrull/marmot/corerepositorymock"
+	expect "github.com/kkrull/marmot/testsupportexpect"
+	"github.com/kkrull/marmot/use"
+	"github.com/kkrull/marmot/userepository"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RegisterLocalRepositoriesCommand", func() {
+	var (
+		factory use.CommandFactory
+		source  *mock.RepositorySource
+		subject *userepository.RegisterLocalRepositoriesCommand
+	)
+
+	Describe("#Run", func() {
+		It("exists", func() {
+			source = mock.NewRepositorySource()
+			factory = use.NewCommandFactory().WithRepositorySource(source)
+			subject = expect.NoError(factory.NewRegisterLocalRepositories())
+			Expect(subject).NotTo(BeNil())
+		})
+	})
+})

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -23,9 +23,17 @@ var _ = Describe("RegisterLocalRepositoriesCommand", func() {
 	})
 
 	Describe("#Run", func() {
-		It("passes local paths to the repository source", Pending, func() {
-			Expect(subject).NotTo(BeNil())
+		It("passes local paths to the repository source", func() {
 			subject.Run("/path/to/repo")
+			source.AddLocalExpected("/path/to/repo")
+		})
+
+		It("returns nil when everything succeeds", func() {
+			Expect(subject.Run(validPath())).To(Succeed())
 		})
 	})
 })
+
+func validPath() string {
+	return "/path/to/repo"
+}

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -1,6 +1,8 @@
 package userepository_test
 
 import (
+	"errors"
+
 	mock "github.com/kkrull/marmot/corerepositorymock"
 	expect "github.com/kkrull/marmot/testsupportexpect"
 	"github.com/kkrull/marmot/use"
@@ -30,6 +32,11 @@ var _ = Describe("RegisterLocalRepositoriesCommand", func() {
 
 		It("returns nil when everything succeeds", func() {
 			Expect(subject.Run(validPath())).To(Succeed())
+		})
+
+		It("returns informative errors, when they occur", func() {
+			source.AddLocalFails("/path/to/faulty-repo", errors.New("bang!"))
+			Expect(subject.Run("/path/to/faulty-repo")).To(MatchError("failed to add local repository /path/to/faulty-repo: bang!"))
 		})
 	})
 })

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -16,12 +16,16 @@ var _ = Describe("RegisterLocalRepositoriesCommand", func() {
 		subject *userepository.RegisterLocalRepositoriesCommand
 	)
 
+	BeforeEach(func() {
+		source = mock.NewRepositorySource()
+		factory = use.NewCommandFactory().WithRepositorySource(source)
+		subject = expect.NoError(factory.NewRegisterLocalRepositories())
+	})
+
 	Describe("#Run", func() {
-		It("exists", func() {
-			source = mock.NewRepositorySource()
-			factory = use.NewCommandFactory().WithRepositorySource(source)
-			subject = expect.NoError(factory.NewRegisterLocalRepositories())
+		It("passes local paths to the repository source", Pending, func() {
 			Expect(subject).NotTo(BeNil())
+			subject.Run("/path/to/repo")
 		})
 	})
 })

--- a/src/go/userepository/register_remote_repositories_command_test.go
+++ b/src/go/userepository/register_remote_repositories_command_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("RegisterRepositoriesCommand", func() {
+var _ = Describe("RegisterRemoteRepositoriesCommand", func() {
 	var (
 		factory use.CommandFactory
 		source  *mock.RepositorySource


### PR DESCRIPTION
# Changes

## Primary change

Add `RegisterLocalRepositoryCommand` and `ListLocalRepositories` query.

## Supporting changes

- Organize step definitions by the kind of repository.

## Future work

- Add business logic for edge cases to commands, for faulty paths, paths that aren't Git repositories, etc...
- Re-visit testing.

## Version

Same.
