### PR TITLE
Add local command to CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-json
+        exclude: .vscode/launch.json
       - id: check-yaml
       - id: trailing-whitespace
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,10 @@
       "args": [
         "local",
         "register",
-        "$(workspaceFolder)"
+        "."
       ],
       "mode": "auto",
-      "name": "marmot local register",
+      "name": "marmot local register .",
       "program": "${workspaceFolder}/src/go/main.go",
       "request": "launch",
       "type": "go"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,18 @@
     },
     {
       "args": [
+        "local",
+        "register",
+        "$(workspaceFolder)"
+      ],
+      "mode": "auto",
+      "name": "marmot local register",
+      "program": "${workspaceFolder}/src/go/main.go",
+      "request": "launch",
+      "type": "go"
+    },
+    {
+      "args": [
         "remote",
         "list"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "configurations": [
+    {
+      "args": [
+        "local",
+        "list"
+      ],
+      "mode": "auto",
+      "name": "marmot local list",
+      "program": "${workspaceFolder}/src/go/main.go",
+      "request": "launch",
+      "type": "go"
+    },
+    {
+      "args": [
+        "remote",
+        "list"
+      ],
+      "mode": "auto",
+      "name": "marmot remote list",
+      "program": "${workspaceFolder}/src/go/main.go",
+      "request": "launch",
+      "type": "go"
+    }
+  ],
+  "version": "0.2.0"
+}

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -18,6 +18,7 @@ ignoreWords: []
 import: []
 version: "0.2"
 words:
+  - cmdlocal
   - cmdremote
   - cmdroot
   - corerepository

--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	cmdlocal "github.com/kkrull/marmot/cmd/local"
 	cmdroot "github.com/kkrull/marmot/cmd/root"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +30,7 @@ func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
 		Use:     "local",
 	}
 
-	// cmdremote.NewListCommand().AddToCobra(remoteCobraCmd)
+	cmdlocal.NewListCommand().AddToCobra(remoteCobraCmd)
 	// cmdremote.NewRegisterCommand().AddToCobra(remoteCobraCmd)
 	return remoteCobraCmd
 }

--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -21,7 +21,7 @@ func (cliCmd *localCommand) AddToCobra(cobraCmd *cobra.Command) {
 }
 
 func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
-	remoteCobraCmd := &cobra.Command{
+	localCobraCmd := &cobra.Command{
 		Args:    cobra.NoArgs,
 		GroupID: repositoryGroup.id(),
 		Long:    "Deal with repositories on the local filesystem.",
@@ -30,9 +30,9 @@ func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
 		Use:     "local",
 	}
 
-	cmdlocal.NewListCommand().AddToCobra(remoteCobraCmd)
-	cmdlocal.NewRegisterCommand().AddToCobra(remoteCobraCmd)
-	return remoteCobraCmd
+	cmdlocal.NewListCommand().AddToCobra(localCobraCmd)
+	cmdlocal.NewRegisterCommand().AddToCobra(localCobraCmd)
+	return localCobraCmd
 }
 
 func runLocalCobra(cli *cobra.Command, args []string) error {

--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	cmdroot "github.com/kkrull/marmot/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+// Construct a CLI command to deal with repositories on the local filesystem.
+func NewLocalCommand() *localCommand {
+	return &localCommand{}
+}
+
+type localCommand struct{}
+
+/* Mapping to Cobra */
+
+// Add this command as a sub-command of the given Cobra command.
+func (cliCmd *localCommand) AddToCobra(cobraCmd *cobra.Command) {
+	cobraCmd.AddCommand(cliCmd.toCobraCommand())
+}
+
+func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
+	remoteCobraCmd := &cobra.Command{
+		Args:    cobra.NoArgs,
+		GroupID: repositoryGroup.id(),
+		Long:    "Deal with repositories on the local filesystem.",
+		RunE:    runLocalCobra,
+		Short:   "Deal with local repositories",
+		Use:     "local",
+	}
+
+	// cmdremote.NewListCommand().AddToCobra(remoteCobraCmd)
+	// cmdremote.NewRegisterCommand().AddToCobra(remoteCobraCmd)
+	return remoteCobraCmd
+}
+
+func runLocalCobra(cli *cobra.Command, args []string) error {
+	if parser, newErr := cmdroot.RootConfigParser(); newErr != nil {
+		return newErr
+	} else if config, parseErr := parser.Parse(cli.Flags(), args); parseErr != nil {
+		return parseErr
+	} else if config.Debug() {
+		config.PrintDebug(cli.OutOrStdout())
+		return nil
+	} else if len(args) == 0 {
+		return cli.Help()
+	} else {
+		// Run the sub-command named in the arguments
+		return nil
+	}
+}

--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -31,7 +31,7 @@ func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
 	}
 
 	cmdlocal.NewListCommand().AddToCobra(remoteCobraCmd)
-	// cmdremote.NewRegisterCommand().AddToCobra(remoteCobraCmd)
+	cmdlocal.NewRegisterCommand().AddToCobra(remoteCobraCmd)
 	return remoteCobraCmd
 }
 

--- a/src/go/cmd/local/list.go
+++ b/src/go/cmd/local/list.go
@@ -1,4 +1,4 @@
-package cmdremote
+package cmdlocal
 
 import (
 	"fmt"
@@ -8,22 +8,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Construct a CLI command to list remote repositories.
-func NewListCommand() *listRemoteCommand {
-	return &listRemoteCommand{}
+// Construct a CLI command to list local repositories.
+func NewListCommand() *listLocalCommand {
+	return &listLocalCommand{}
 }
 
-type listRemoteCommand struct{}
+type listLocalCommand struct{}
 
 func runList(config cmdroot.CliConfig, stdout io.Writer) error {
 	queryFactory := config.QueryFactory()
-	if listRepositories, appErr := queryFactory.NewListRemoteRepositories(); appErr != nil {
+	if listRepositories, appErr := queryFactory.NewListLocalRepositories(); appErr != nil {
 		return appErr
 	} else if repositories, runErr := listRepositories(); runErr != nil {
 		return runErr
 	} else {
-		for _, remoteHref := range repositories.RemoteHrefs() {
-			fmt.Fprintf(stdout, "%s\n", remoteHref)
+		for _, localPath := range repositories.LocalPaths() {
+			fmt.Fprintf(stdout, "%s\n", localPath)
 		}
 		return nil
 	}
@@ -32,11 +32,11 @@ func runList(config cmdroot.CliConfig, stdout io.Writer) error {
 /* Mapping to Cobra */
 
 // Add this command as a sub-command of the given Cobra command.
-func (cliCmd *listRemoteCommand) AddToCobra(cobraCmd *cobra.Command) {
+func (cliCmd *listLocalCommand) AddToCobra(cobraCmd *cobra.Command) {
 	cobraCmd.AddCommand(cliCmd.toCobraCommand())
 }
 
-func (listRemoteCommand) toCobraCommand() *cobra.Command {
+func (listLocalCommand) toCobraCommand() *cobra.Command {
 	return &cobra.Command{
 		Args:  cobra.NoArgs,
 		Long:  "List remote repositories registered with Marmot.",

--- a/src/go/cmd/local/list.go
+++ b/src/go/cmd/local/list.go
@@ -39,9 +39,9 @@ func (cliCmd *listLocalCommand) AddToCobra(cobraCmd *cobra.Command) {
 func (listLocalCommand) toCobraCommand() *cobra.Command {
 	return &cobra.Command{
 		Args:  cobra.NoArgs,
-		Long:  "List remote repositories registered with Marmot.",
+		Long:  "List local repositories registered with Marmot.",
 		RunE:  runListCobra,
-		Short: "List remote repositories",
+		Short: "List local repositories",
 		Use:   "list",
 	}
 }

--- a/src/go/cmd/local/register.go
+++ b/src/go/cmd/local/register.go
@@ -1,0 +1,57 @@
+package cmdlocal
+
+import (
+	cmdroot "github.com/kkrull/marmot/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+// Construct a CLI command to register local repositories.
+func NewRegisterCommand() *registerLocalCommand {
+	return &registerLocalCommand{}
+}
+
+type registerLocalCommand struct{}
+
+func runRegister(config cmdroot.CliConfig) error {
+	if appCmd, appErr := config.CommandFactory().NewRegisterLocalRepositories(); appErr != nil {
+		return appErr
+	} else {
+		argsThenInputLines := config.ArgsTrimmed()
+		argsThenInputLines = append(argsThenInputLines, config.InputLinesTrimmed()...)
+		return appCmd.Run(argsThenInputLines...)
+	}
+}
+
+/* Mapping to Cobra */
+
+// Add this command as a sub-command of the given Cobra command.
+func (cliCmd *registerLocalCommand) AddToCobra(cobraCmd *cobra.Command) {
+	cobraCmd.AddCommand(cliCmd.toCobraCommand())
+}
+
+func (registerLocalCommand) toCobraCommand() *cobra.Command {
+	return &cobra.Command{
+		Args:                  cobra.MinimumNArgs(1),
+		DisableFlagsInUseLine: true,
+		Example: `marmot local register ~/git/drwily.github.com/skull-fortress
+find ~/git -type d -name '.git' -exec marmot local register - {} +`,
+		Long: `Register Git repositories on the local filesystem at each [PATH].
+When PATH is -, stop processing arguments and read newline-delimited paths from standard input.`,
+		RunE:  runRegisterCobra,
+		Short: "Register local repositories",
+		Use:   "register [flags] [URL]... [-]",
+	}
+}
+
+func runRegisterCobra(cli *cobra.Command, args []string) error {
+	if parser, newErr := cmdroot.RootConfigParser(); newErr != nil {
+		return newErr
+	} else if config, parseErr := parser.ParseR(cli.Flags(), args, cli.InOrStdin()); parseErr != nil {
+		return parseErr
+	} else if config.Debug() {
+		config.PrintDebug(cli.OutOrStdout())
+		return nil
+	} else {
+		return runRegister(config)
+	}
+}

--- a/src/go/cmd/remote/register.go
+++ b/src/go/cmd/remote/register.go
@@ -10,11 +10,11 @@ import (
 )
 
 // Construct a CLI command to register remote repositories.
-func NewRegisterCommand() *registerCommand {
-	return &registerCommand{}
+func NewRegisterCommand() *registerRemoteCommand {
+	return &registerRemoteCommand{}
 }
 
-type registerCommand struct{}
+type registerRemoteCommand struct{}
 
 func runRegister(config cmdroot.CliConfig) error {
 	if appCmd, appErr := config.CommandFactory().NewRegisterRemoteRepositories(); appErr != nil {
@@ -31,11 +31,11 @@ func runRegister(config cmdroot.CliConfig) error {
 /* Mapping to Cobra */
 
 // Add this command as a sub-command of the given Cobra command.
-func (cliCmd *registerCommand) AddToCobra(cobraCmd *cobra.Command) {
+func (cliCmd *registerRemoteCommand) AddToCobra(cobraCmd *cobra.Command) {
 	cobraCmd.AddCommand(cliCmd.toCobraCommand())
 }
 
-func (registerCommand) toCobraCommand() *cobra.Command {
+func (registerRemoteCommand) toCobraCommand() *cobra.Command {
 	return &cobra.Command{
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -41,6 +41,7 @@ func (root rootCliCommand) ToCobraCommand() *cobra.Command {
 	}
 
 	NewInitCommand().AddToCobra(rootCmd)
+	NewLocalCommand().AddToCobra(rootCmd)
 	NewRemoteCommand().AddToCobra(rootCmd)
 
 	rootCmd.SetOut(root.stdout)

--- a/src/go/cmd/root/cli_config.go
+++ b/src/go/cmd/root/cli_config.go
@@ -28,6 +28,9 @@ type CliConfig interface {
 	// Positional arguments parsed as URLs.
 	ArgsAsUrls() ([]*url.URL, error)
 
+	// Positional arguments trimmed for whitespace.
+	ArgsTrimmed() []string
+
 	/* CLI debugging */
 
 	// Print information for debugging CLI parsing to the given writer.
@@ -46,8 +49,11 @@ type CliConfig interface {
 	// Lines of text input from another process–e.g. through a pipe to standard input–as raw text.
 	InputLines() []string
 
-	// Lines of text input from another process–e.g. through a pipe to standard input–parsed as URLs.
+	// Lines of text input from another process–e.g. read from standard input–parsed as URLs.
 	InputLinesAsUrls() ([]*url.URL, error)
+
+	// Lines of text input from another process–e.g. read from standard input–trimmed for whitespace.
+	InputLinesTrimmed() []string
 }
 
 // Application configuration derived from flags passed to the CLI.
@@ -90,6 +96,15 @@ func (params rootCliConfig) ArgsAsUrls() ([]*url.URL, error) {
 	return urls, nil
 }
 
+func (params rootCliConfig) ArgsTrimmed() []string {
+	trimmed := make([]string, len(params.args))
+	for i, rawArg := range params.args {
+		trimmed[i] = strings.TrimSpace(rawArg)
+	}
+
+	return trimmed
+}
+
 /* CLI debugging */
 
 func (params rootCliConfig) Debug() bool { return params.debug }
@@ -130,4 +145,13 @@ func (params rootCliConfig) InputLinesAsUrls() ([]*url.URL, error) {
 	}
 
 	return urls, nil
+}
+
+func (params rootCliConfig) InputLinesTrimmed() []string {
+	trimmed := make([]string, len(params.inputLines))
+	for i, rawLine := range params.inputLines {
+		trimmed[i] = strings.TrimSpace(rawLine)
+	}
+
+	return trimmed
 }

--- a/src/go/cmd/root/cli_config.go
+++ b/src/go/cmd/root/cli_config.go
@@ -76,16 +76,16 @@ type rootCliConfig struct {
 
 /* Application interface */
 
-func (params rootCliConfig) CommandFactory() use.CommandFactory { return params.cmdFactory }
-func (params rootCliConfig) QueryFactory() use.QueryFactory     { return params.queryFactory }
+func (config rootCliConfig) CommandFactory() use.CommandFactory { return config.cmdFactory }
+func (config rootCliConfig) QueryFactory() use.QueryFactory     { return config.queryFactory }
 
 /* CLI arguments */
 
-func (params rootCliConfig) Args() []string { return params.args }
+func (config rootCliConfig) Args() []string { return config.args }
 
-func (params rootCliConfig) ArgsAsUrls() ([]*url.URL, error) {
-	urls := make([]*url.URL, len(params.args))
-	for i, rawArg := range params.args {
+func (config rootCliConfig) ArgsAsUrls() ([]*url.URL, error) {
+	urls := make([]*url.URL, len(config.args))
+	for i, rawArg := range config.args {
 		if urlArg, parseErr := url.Parse(rawArg); parseErr != nil {
 			return nil, fmt.Errorf("url expected: <%s>; %w", rawArg, parseErr)
 		} else {
@@ -96,9 +96,9 @@ func (params rootCliConfig) ArgsAsUrls() ([]*url.URL, error) {
 	return urls, nil
 }
 
-func (params rootCliConfig) ArgsTrimmed() []string {
-	trimmed := make([]string, len(params.args))
-	for i, rawArg := range params.args {
+func (config rootCliConfig) ArgsTrimmed() []string {
+	trimmed := make([]string, len(config.args))
+	for i, rawArg := range config.args {
 		trimmed[i] = strings.TrimSpace(rawArg)
 	}
 
@@ -107,33 +107,33 @@ func (params rootCliConfig) ArgsTrimmed() []string {
 
 /* CLI debugging */
 
-func (params rootCliConfig) Debug() bool { return params.debug }
+func (config rootCliConfig) Debug() bool { return config.debug }
 
-func (params rootCliConfig) PrintDebug(writer io.Writer) {
-	for i, arg := range params.args {
+func (config rootCliConfig) PrintDebug(writer io.Writer) {
+	for i, arg := range config.args {
 		fmt.Fprintf(writer, "arg [%d]: %s\n", i, arg)
 	}
 
 	for _, flag := range rootFlags {
-		fmt.Fprintf(writer, "flag --%s=%s\n", flag.LongName(), flag.Find(params.flagSet))
+		fmt.Fprintf(writer, "flag --%s=%s\n", flag.LongName(), flag.Find(config.flagSet))
 	}
 
-	for i, line := range params.inputLines {
+	for i, line := range config.inputLines {
 		fmt.Fprintf(writer, "stdin [%d]: %s\n", i, line)
 	}
 }
 
 /* CLI flags */
 
-func (params rootCliConfig) MetaRepoPath() string { return params.metaRepoPath }
+func (config rootCliConfig) MetaRepoPath() string { return config.metaRepoPath }
 
 /* CLI input */
 
-func (params rootCliConfig) InputLines() []string { return params.inputLines }
+func (config rootCliConfig) InputLines() []string { return config.inputLines }
 
-func (params rootCliConfig) InputLinesAsUrls() ([]*url.URL, error) {
+func (config rootCliConfig) InputLinesAsUrls() ([]*url.URL, error) {
 	urls := make([]*url.URL, 0)
-	for _, rawLine := range params.inputLines {
+	for _, rawLine := range config.inputLines {
 		trimmedLine := strings.TrimSpace(rawLine)
 		if trimmedLine == "" {
 			continue
@@ -147,9 +147,9 @@ func (params rootCliConfig) InputLinesAsUrls() ([]*url.URL, error) {
 	return urls, nil
 }
 
-func (params rootCliConfig) InputLinesTrimmed() []string {
-	trimmed := make([]string, len(params.inputLines))
-	for i, rawLine := range params.inputLines {
+func (config rootCliConfig) InputLinesTrimmed() []string {
+	trimmed := make([]string, len(config.inputLines))
+	for i, rawLine := range config.inputLines {
 		trimmed[i] = strings.TrimSpace(rawLine)
 	}
 

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -68,8 +68,10 @@ func (parser rootConfigParser) ParseR(
 		return nil, pathErr
 	} else {
 		argsBeforeDash := make([]string, 0)
+		readFromStdin := false
 		for _, arg := range args {
 			if strings.TrimSpace(arg) == "-" {
+				readFromStdin = true
 				break
 			} else {
 				argsBeforeDash = append(argsBeforeDash, arg)
@@ -77,13 +79,15 @@ func (parser rootConfigParser) ParseR(
 		}
 
 		inputLines := make([]string, 0)
-		scanner := bufio.NewScanner(stdin)
-		for scanner.Scan() {
-			line := scanner.Text()
-			inputLines = append(inputLines, line)
-		}
-		if scanErr := scanner.Err(); scanErr != nil {
-			return nil, scanErr
+		if readFromStdin {
+			scanner := bufio.NewScanner(stdin)
+			for scanner.Scan() {
+				line := scanner.Text()
+				inputLines = append(inputLines, line)
+			}
+			if scanErr := scanner.Err(); scanErr != nil {
+				return nil, scanErr
+			}
 		}
 
 		metaRepoAdmin := svcfs.NewJsonMetaRepoAdmin(parser.version)


### PR DESCRIPTION
# Changes

## Primary change

Add `marmot local [list|register]` to Go CLI.

## Supporting changes

Fix bug when parsing command line arguments, where it would try to read from an
empty (never-ending) stdin without the `-` argument.

## Future work

- Add edge cases to business logic, to check that they are valid paths.
- Resolve relative paths, such as `.`.

## Version

Same
