### PR TITLE
Measure Go code coverage

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - run: go version
       - run: go get -t -v .
+      - run: make install-tools
 
   go-build:
     defaults:
@@ -57,7 +58,6 @@ jobs:
           cache-dependency-path: src/go/go.sum
           go-version-file: src/go/go.mod
 
-      - run: go test -v ./...
       - run: make test-coverage
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -24,7 +24,6 @@ jobs:
 
       - run: go version
       - run: go get -t -v .
-      - run: make install-tools
 
   go-build:
     defaults:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,7 +40,6 @@ jobs:
           cache-dependency-path: src/go/go.sum
           go-version-file: src/go/go.mod
 
-      #      - run: go get -v .
       - run: go build -v ./...
 
   go-test:
@@ -58,5 +57,9 @@ jobs:
           cache-dependency-path: src/go/go.sum
           go-version-file: src/go/go.mod
 
-      #     - run: go get -v .
       - run: go test -v ./...
+      - run: make test-coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage-go
+          path: src/go/coverage.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "go.buildTags": "-coverpkg ./..."
+}

--- a/man/Makefile
+++ b/man/Makefile
@@ -10,11 +10,16 @@ default: all
 ### Paths
 
 prefix ?= /usr/local
-
 datarootdir := $(prefix)/share
 mandir := $(datarootdir)/man
+
 man1dir := $(mandir)/man1
+$(man1dir):
+	mkdir -p $@
+
 man7dir := $(mandir)/man7
+$(man7dir):
+	mkdir -p $@
 
 .PHONY: path-info
 path-info:
@@ -112,8 +117,7 @@ groff-manual-info: #> Show build information for groff
 	@:
 
 .PHONY: groff-manual-install
-groff-manual-install: $(groff_man1_objects) $(groff_man7_objects) #> Install man pages
-	mkdir -p $(man1dir) $(man7dir)
+groff-manual-install: $(groff_man1_objects) $(groff_man7_objects) | $(man1dir) $(man7dir) #> Install man pages
 	install -g 0 -o 0 -m 0644 $(groff_man1_objects) $(man1dir)
 	install -g 0 -o 0 -m 0644 $(groff_man7_objects) $(man7dir)
 
@@ -138,7 +142,10 @@ groff/%: pandoc/%.md
 #. MARKDOWN MANUAL TARGETS
 
 markdown_manual_objects := $(patsubst pandoc/%.md,markdown/%.md,$(sources))
+
 markdown_manual_objects_dir := markdown
+$(markdown_manual_objects_dir):
+	mkdir -p $@
 
 .PHONY: markdown-manual
 markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are part of this repo
@@ -157,9 +164,6 @@ markdown-manual-info: #> Show build information for the markdown manual
 # Make sure directory exists before building targets
 # https://www.gnu.org/savannah-checkouts/gnu/make/manual/html_node/Prerequisite-Types.html
 $(markdown_manual_objects): | $(markdown_manual_objects_dir)
-
-$(markdown_manual_objects_dir):
-	mkdir -p markdown
 
 markdown/%.md: pandoc/%.md
 	$(PANDOC) $< $(PANDOCFLAGS) -o $@ -s -t gfm

--- a/man/Makefile
+++ b/man/Makefile
@@ -136,16 +136,22 @@ groff-manual-watch: #> Emit rendered man pages when Pandoc sources change
 		| xargs -I {} echo "$(PANDOC) {} $(PANDOCFLAGS) -s -t man | $(MANDOC)" \
 		| sh
 
-groff/%: pandoc/%.md
+groff:
+	mkdir -p $@
+
+groff/%: pandoc/%.md | groff
 	$(PANDOC) $< $(PANDOCFLAGS) -o $@ -s -t man
 
 #. MARKDOWN MANUAL TARGETS
 
-markdown_manual_objects := $(patsubst pandoc/%.md,markdown/%.md,$(sources))
-
 markdown_manual_objects_dir := markdown
 $(markdown_manual_objects_dir):
 	mkdir -p $@
+
+# Make sure directory exists before building targets, but directory update doesn't cause re-build
+# https://www.gnu.org/savannah-checkouts/gnu/make/manual/html_node/Prerequisite-Types.html
+markdown_manual_objects := $(patsubst pandoc/%.md,markdown/%.md,$(sources))
+$(markdown_manual_objects): | $(markdown_manual_objects_dir)
 
 .PHONY: markdown-manual
 markdown-manual: $(markdown_manual_objects) #> Build Markdown manuals which are part of this repo
@@ -160,10 +166,6 @@ markdown-manual-info: #> Show build information for the markdown manual
 	$(info - markdown_manual_objects: $(markdown_manual_objects))
 	$(info - markdown_manual_objects_dir: $(markdown_manual_objects_dir))
 	@:
-
-# Make sure directory exists before building targets
-# https://www.gnu.org/savannah-checkouts/gnu/make/manual/html_node/Prerequisite-Types.html
-$(markdown_manual_objects): | $(markdown_manual_objects_dir)
 
 markdown/%.md: pandoc/%.md
 	$(PANDOC) $< $(PANDOCFLAGS) -o $@ -s -t gfm

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -4,5 +4,6 @@ marmot
 marmot.exe
 
 # Testing
-coverprofile.out
+coverage.html
+coverage.out
 cukefeature/localDir

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -4,4 +4,5 @@ marmot
 marmot.exe
 
 # Testing
+coverprofile.out
 cukefeature/localDir

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -6,4 +6,5 @@ marmot.exe
 # Testing
 coverage.html
 coverage.out
+coverage-gaps.out
 cukefeature/localDir

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -184,8 +184,10 @@ $(autocomplete): $(executable)
 coverage.html: coverage.out
 	go tool cover -html $< -o $@
 
+coveragepackages := $(shell go list -f '{{ .ImportPath }}' github.com/kkrull/marmot/... | jq -nR -r '[inputs] | join(",")')
 coverage.out: $(sources)
-	ginkgo run -coverpkg github.com/kkrull/... -coverprofile $@ ./...
+	$(info $(packages))
+	ginkgo run -coverpkg=$(coveragepackages) -coverprofile $@ ./...
 
 coverage-gaps.out: coverage.out
 	uncover $< > $@

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -103,7 +103,7 @@ all: $(executable) $(autocomplete) #> Build all sources
 
 .PHONY: clean
 clean: #> Remove local build files
-	$(RM) $(autocomplete) coverage.html coverage.out $(executable)
+	$(RM) $(autocomplete) coverage.html coverage.out coverage-gaps.out $(executable)
 
 .PHONY: install
 install: $(executable) | $(bindir) $(datadirpkg) $(libexecdirpkg) #> Install program
@@ -146,13 +146,14 @@ install-autocomplete-zsh: $(autocomplete) | $(datadirzshfn) #> Install autocompl
 .PHONY: install-tools
 install-tools: #> Install Go development tools
 	go install github.com/go-delve/delve/cmd/dlv@latest
+	go install github.com/gregoryv/uncover/cmd/uncover@latest
 	go install github.com/onsi/ginkgo/v2/ginkgo
 	go install github.com/spf13/cobra-cli@latest
 	go install golang.org/x/tools/cmd/godoc@latest
 	go install mvdan.cc/gofumpt@latest
 
 .PHONY: test-coverage
-test-coverage: coverage.html #> Run tests with code coverage
+test-coverage: coverage.html coverage-gaps.out #> Run tests with code coverage
 	@:
 
 .PHONY: test-watch
@@ -185,6 +186,9 @@ coverage.html: coverage.out
 
 coverage.out: $(sources)
 	ginkgo run -coverpkg github.com/kkrull/... -coverprofile $@ ./...
+
+coverage-gaps.out: coverage.out
+	uncover $< > $@
 
 $(executable): $(sources)
 	go build -o $(executable) $(source_main)

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -103,7 +103,7 @@ all: $(executable) $(autocomplete) #> Build all sources
 
 .PHONY: clean
 clean: #> Remove local build files
-	$(RM) $(autocomplete) $(executable)
+	$(RM) $(autocomplete) coverage.html coverage.out $(executable)
 
 .PHONY: install
 install: $(executable) | $(bindir) $(datadirpkg) $(libexecdirpkg) #> Install program
@@ -152,9 +152,14 @@ install-tools: #> Install Go development tools
 	go install mvdan.cc/gofumpt@latest
 
 .PHONY: test-coverage
-test-coverage: #> Run tests with code coverage
-	ginkgo run -coverpkg github.com/kkrull/... -coverprofile coverage.out ./...
-	go tool cover -html coverage.out -o coverage.html
+test-coverage: coverage.html #> Run tests with code coverage
+	@:
+
+coverage.html: coverage.out
+	go tool cover -html $< -o $@
+
+coverage.out: $(sources)
+	ginkgo run -coverpkg github.com/kkrull/... -coverprofile $@ ./...
 
 .PHONY: test-watch
 test-watch: #> Run tests in watch mode

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -184,10 +184,9 @@ $(autocomplete): $(executable)
 coverage.html: coverage.out
 	go tool cover -html $< -o $@
 
-coveragepackages := $(shell go list -f '{{ .ImportPath }}' github.com/kkrull/marmot/... | jq -nR -r '[inputs] | join(",")')
+# Use `go test` instead of `ginkgo` to include packages that have no coverage
 coverage.out: $(sources)
-	$(info $(packages))
-	ginkgo run -coverpkg=$(coveragepackages) -coverprofile $@ ./...
+	go test -coverpkg=./... -coverprofile $@ ./...
 
 coverage-gaps.out: coverage.out
 	uncover $< > $@

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -32,14 +32,23 @@ exec_prefix ?= $(prefix)
 # Executable programs that users can run (including symlinks)
 bindir := $(exec_prefix)/bin
 
+$(bindir):
+	mkdir -p $(bindir)
+
 # Executable programs to be run by other programs, in a subdirectory thereof
 libexecdir := $(exec_prefix)/libexec
 libexecdirpkg := $(libexecdir)/marmot
+
+$(libexecdirpkg):
+	mkdir -p $(libexecdirpkg)
 
 # Read-only architecture-independent data files, in a subdirectory thereof
 datarootdir := $(prefix)/share
 datadir := $(datarootdir)
 datadirpkg := $(datadir)/marmot
+
+$(datadirpkg):
+	mkdir -p $(datadirpkg)
 
 # Autocomplete scripts
 # https://unix.stackexchange.com/a/607810/37734
@@ -98,8 +107,7 @@ clean: #> Remove local build files
 	$(RM) $(autocomplete) $(executable)
 
 .PHONY: install
-install: $(executable) #> Install program
-	mkdir -p $(bindir) $(datadirpkg) $(libexecdirpkg)
+install: $(executable) | $(bindir) $(datadirpkg) $(libexecdirpkg) #> Install program
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
 
 	install $(INSTALLFLAGS) -m 0644 $(versionfile) $(datadirpkg)

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -155,12 +155,6 @@ install-tools: #> Install Go development tools
 test-coverage: coverage.html #> Run tests with code coverage
 	@:
 
-coverage.html: coverage.out
-	go tool cover -html $< -o $@
-
-coverage.out: $(sources)
-	ginkgo run -coverpkg github.com/kkrull/... -coverprofile $@ ./...
-
 .PHONY: test-watch
 test-watch: #> Run tests in watch mode
 	ginkgo watch -r
@@ -185,6 +179,12 @@ update: #> Update Go dependencies
 
 $(autocomplete): $(executable)
 	./$(executable) completion zsh > $(autocomplete)
+
+coverage.html: coverage.out
+	go tool cover -html $< -o $@
+
+coverage.out: $(sources)
+	ginkgo run -coverpkg github.com/kkrull/... -coverprofile $@ ./...
 
 $(executable): $(sources)
 	go build -o $(executable) $(source_main)

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -31,22 +31,21 @@ exec_prefix ?= $(prefix)
 
 # Executable programs that users can run (including symlinks)
 bindir := $(exec_prefix)/bin
-
 $(bindir):
 	mkdir -p $(bindir)
 
 # Executable programs to be run by other programs, in a subdirectory thereof
 libexecdir := $(exec_prefix)/libexec
-libexecdirpkg := $(libexecdir)/marmot
 
+libexecdirpkg := $(libexecdir)/marmot
 $(libexecdirpkg):
 	mkdir -p $(libexecdirpkg)
 
 # Read-only architecture-independent data files, in a subdirectory thereof
 datarootdir := $(prefix)/share
 datadir := $(datarootdir)
-datadirpkg := $(datadir)/marmot
 
+datadirpkg := $(datadir)/marmot
 $(datadirpkg):
 	mkdir -p $(datadirpkg)
 
@@ -109,7 +108,6 @@ clean: #> Remove local build files
 .PHONY: install
 install: $(executable) | $(bindir) $(datadirpkg) $(libexecdirpkg) #> Install program
 	ln -f -s $(libexecdirpkg)/$(executable) $(bindir)/marmot
-
 	install $(INSTALLFLAGS) -m 0644 $(versionfile) $(datadirpkg)
 	install $(INSTALLFLAGS) -m 0755 $(executable) $(libexecdirpkg)
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -144,6 +144,10 @@ install-tools: #> Install Go development tools
 	go install golang.org/x/tools/cmd/godoc@latest
 	go install mvdan.cc/gofumpt@latest
 
+.PHONY: test-coverage
+test-coverage: #> Run tests with code coverage
+	ginkgo run -coverpkg ./... -r
+
 .PHONY: test-watch
 test-watch: #> Run tests in watch mode
 	ginkgo watch -r

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -153,7 +153,7 @@ install-tools: #> Install Go development tools
 	go install mvdan.cc/gofumpt@latest
 
 .PHONY: test-coverage
-test-coverage: coverage.html coverage-gaps.out #> Run tests with code coverage
+test-coverage: coverage.html #> Run tests with code coverage
 	@:
 
 .PHONY: test-watch

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -44,6 +44,8 @@ datadirpkg := $(datadir)/marmot
 # Autocomplete scripts
 # https://unix.stackexchange.com/a/607810/37734
 datadirzshfn := $(datadir)/zsh/site-functions
+$(datadirzshfn):
+	mkdir -p $(datadirzshfn)
 
 .PHONY: path-info
 path-info:
@@ -131,8 +133,7 @@ info: artifact-info path-info program-info source-info #> Show build information
 	@:
 
 .PHONY: install-autocomplete-zsh
-install-autocomplete-zsh: $(autocomplete) #> Install autocomplete script for zsh
-	mkdir -p $(datadirzshfn)
+install-autocomplete-zsh: $(autocomplete) | $(datadirzshfn) #> Install autocomplete script for zsh
 	install $(INSTALLFLAGS) -m 0644 $(autocomplete) $(datadirzshfn)
 	@echo 'Run `source $(datadirzshfn)/$(autocomplete)` to enable auto-completion in zsh.'
 

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -146,7 +146,8 @@ install-tools: #> Install Go development tools
 
 .PHONY: test-coverage
 test-coverage: #> Run tests with code coverage
-	ginkgo run -coverpkg ./... -r
+	ginkgo run -coverpkg github.com/kkrull/... -coverprofile coverage.out ./...
+	go tool cover -html coverage.out -o coverage.html
 
 .PHONY: test-watch
 test-watch: #> Run tests in watch mode

--- a/src/zsh/Makefile
+++ b/src/zsh/Makefile
@@ -9,7 +9,10 @@ default: all
 
 prefix ?= /usr/local
 exec_prefix ?= $(prefix)
+
 bindir := $(exec_prefix)/bin
+$(bindir):
+	mkdir -p $(bindir)
 
 .PHONY: path-info
 path-info:
@@ -42,8 +45,7 @@ clean:
 	@:
 
 .PHONY: install
-install: #> Install symlink to sources
-	mkdir -p $(bindir)
+install: | $(bindir) #> Install symlink to sources
 	ln -f -s $(srcdir)/marmot.zsh $(bindir)/marmot
 
 .PHONY: test


### PR DESCRIPTION
- Update GitHub actions to measure code coverage with `go test`
- Add tasks to `Makefile`
- Standardize `Makefile` when creating directories