### PR TITLE
Move rules for initialization to command

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,7 +40,7 @@ jobs:
           cache-dependency-path: src/go/go.sum
           go-version-file: src/go/go.mod
 
-      - run: go build -v ./...
+      - run: make all
 
   go-test:
     defaults:

--- a/src/go/coremetarepo/meta_data_admin.go
+++ b/src/go/coremetarepo/meta_data_admin.go
@@ -4,4 +4,7 @@ package coremetarepo
 type MetaDataAdmin interface {
 	// Create a meta repository at the specified path on the local filesystem.
 	Create(metaRepoPath string) error
+
+	// Returns true if the specified path exists and is already a meta repository.
+	Exists(metaRepoPath string) bool
 }

--- a/src/go/coremetarepo/meta_data_admin.go
+++ b/src/go/coremetarepo/meta_data_admin.go
@@ -6,5 +6,5 @@ type MetaDataAdmin interface {
 	Create(metaRepoPath string) error
 
 	// Returns true if the specified path exists and is already a meta repository.
-	Exists(metaRepoPath string) bool
+	IsMetaRepo(metaRepoPath string) bool
 }

--- a/src/go/coremetarepo/meta_data_admin.go
+++ b/src/go/coremetarepo/meta_data_admin.go
@@ -6,5 +6,5 @@ type MetaDataAdmin interface {
 	Create(metaRepoPath string) error
 
 	// Returns true if the specified path exists and is already a meta repository.
-	IsMetaRepo(metaRepoPath string) bool
+	IsMetaRepo(metaRepoPath string) (bool, error)
 }

--- a/src/go/coremetarepomock/meta_data_admin_mock.go
+++ b/src/go/coremetarepomock/meta_data_admin_mock.go
@@ -8,6 +8,7 @@ import (
 // Construct a test double for MetaDataAdmin.
 func NewMetaDataAdmin() *MetaDataAdmin {
 	return &MetaDataAdmin{
+		isMetaRepoError:   make(map[string]error),
 		isMetaRepoReturns: make(map[string]bool),
 	}
 }
@@ -16,6 +17,7 @@ func NewMetaDataAdmin() *MetaDataAdmin {
 type MetaDataAdmin struct {
 	createCalls       []string
 	createError       error
+	isMetaRepoError   map[string]error
 	isMetaRepoReturns map[string]bool
 }
 
@@ -33,10 +35,11 @@ func (admin *MetaDataAdmin) CreateFails(err error) {
 	admin.createError = err
 }
 
-func (admin *MetaDataAdmin) IsMetaRepo(path string) bool {
-	return admin.isMetaRepoReturns[path]
+func (admin *MetaDataAdmin) IsMetaRepo(path string) (bool, error) {
+	return admin.isMetaRepoReturns[path], admin.isMetaRepoError[path]
 }
 
-func (admin *MetaDataAdmin) IsMetaRepoReturns(path string, value bool) {
+func (admin *MetaDataAdmin) IsMetaRepoReturns(path string, value bool, err error) {
 	admin.isMetaRepoReturns[path] = value
+	admin.isMetaRepoError[path] = err
 }

--- a/src/go/coremetarepomock/meta_data_admin_mock.go
+++ b/src/go/coremetarepomock/meta_data_admin_mock.go
@@ -7,13 +7,16 @@ import (
 
 // Construct a test double for MetaDataAdmin.
 func NewMetaDataAdmin() *MetaDataAdmin {
-	return &MetaDataAdmin{}
+	return &MetaDataAdmin{
+		existsReturns: make(map[string]bool),
+	}
 }
 
 // Mock implementation for testing with MetaDataAdmin.
 type MetaDataAdmin struct {
-	createCalls []string
-	createError error
+	createCalls   []string
+	createError   error
+	existsReturns map[string]bool
 }
 
 func (admin *MetaDataAdmin) Create(metaRepoPath string) error {
@@ -21,17 +24,19 @@ func (admin *MetaDataAdmin) Create(metaRepoPath string) error {
 	return admin.createError
 }
 
-// Assert that a meta repo was created at the specified path.
 func (admin *MetaDataAdmin) CreateExpected(expectedPath string) {
 	ginkgo.GinkgoHelper()
 	Expect(admin.createCalls).To(ContainElement(expectedPath))
 }
 
-// Stub #Create to fail with the given error.
 func (admin *MetaDataAdmin) CreateFails(err error) {
 	admin.createError = err
 }
 
+func (admin *MetaDataAdmin) Exists(path string) bool {
+	return admin.existsReturns[path]
+}
+
 func (admin *MetaDataAdmin) ExistsReturns(path string, value bool) {
-	//TODO KDK: Implement
+	admin.existsReturns[path] = value
 }

--- a/src/go/coremetarepomock/meta_data_admin_mock.go
+++ b/src/go/coremetarepomock/meta_data_admin_mock.go
@@ -31,3 +31,7 @@ func (admin *MetaDataAdmin) CreateExpected(expectedPath string) {
 func (admin *MetaDataAdmin) CreateFails(err error) {
 	admin.createError = err
 }
+
+func (admin *MetaDataAdmin) ExistsReturns(path string, value bool) {
+	//TODO KDK: Implement
+}

--- a/src/go/coremetarepomock/meta_data_admin_mock.go
+++ b/src/go/coremetarepomock/meta_data_admin_mock.go
@@ -8,15 +8,15 @@ import (
 // Construct a test double for MetaDataAdmin.
 func NewMetaDataAdmin() *MetaDataAdmin {
 	return &MetaDataAdmin{
-		existsReturns: make(map[string]bool),
+		isMetaRepoReturns: make(map[string]bool),
 	}
 }
 
 // Mock implementation for testing with MetaDataAdmin.
 type MetaDataAdmin struct {
-	createCalls   []string
-	createError   error
-	existsReturns map[string]bool
+	createCalls       []string
+	createError       error
+	isMetaRepoReturns map[string]bool
 }
 
 func (admin *MetaDataAdmin) Create(metaRepoPath string) error {
@@ -33,10 +33,10 @@ func (admin *MetaDataAdmin) CreateFails(err error) {
 	admin.createError = err
 }
 
-func (admin *MetaDataAdmin) Exists(path string) bool {
-	return admin.existsReturns[path]
+func (admin *MetaDataAdmin) IsMetaRepo(path string) bool {
+	return admin.isMetaRepoReturns[path]
 }
 
-func (admin *MetaDataAdmin) ExistsReturns(path string, value bool) {
-	admin.existsReturns[path] = value
+func (admin *MetaDataAdmin) IsMetaRepoReturns(path string, value bool) {
+	admin.isMetaRepoReturns[path] = value
 }

--- a/src/go/cukesupport/meta_repo_hook.go
+++ b/src/go/cukesupport/meta_repo_hook.go
@@ -20,7 +20,7 @@ func addMetaRepoFixtureAfterLocalDir(ctx *godog.ScenarioContext) {
 }
 
 func afterMetaRepo(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-	//Always clear state; it could have been initialized by a hook _or_ an explicit step
+	// Always clear state; it could have been initialized by a hook _or_ an explicit step
 	forgetThatMetaRepo()
 	return ctx, err
 }

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -27,7 +27,7 @@ func (admin *JsonMetaRepoAdmin) Create(repositoryDir string) error {
 	} else if statErr != nil {
 		return fmt.Errorf("failed to check for existing meta repo %s; %w", repositoryDir, statErr)
 	} else {
-		//Ignore an existing meta repo, for now
+		// Ignore an existing meta repo, for now
 		return nil
 	}
 }

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -27,7 +27,7 @@ func (admin *JsonMetaRepoAdmin) Create(repositoryDir string) error {
 	} else if statErr != nil {
 		return fmt.Errorf("failed to check for existing meta repo %s; %w", repositoryDir, statErr)
 	} else {
-		return fmt.Errorf("path already exists: %s", marmotDataDir)
+		return nil
 	}
 }
 

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -43,19 +43,23 @@ func initDirectory(metaDataFile string, rootObject *rootObjectData) error {
 	}
 }
 
-func (admin *JsonMetaRepoAdmin) IsMetaRepo(path string) bool {
+func (admin *JsonMetaRepoAdmin) IsMetaRepo(path string) (bool, error) {
 	pathStat, pathErr := os.Stat(path)
-	if errors.Is(pathErr, fs.ErrNotExist) || pathErr != nil {
-		return false
+	if errors.Is(pathErr, fs.ErrNotExist) {
+		return false, nil
+	} else if pathErr != nil {
+		return false, fmt.Errorf("%s: failed to stat meta repo path; %w", path, pathErr)
 	} else if pathStat.Mode().IsRegular() {
-		return false
+		return false, nil
 	}
 
 	marmotDir := metaDataDir(path)
 	_, marmotDirErr := os.Stat(marmotDir)
 	if errors.Is(marmotDirErr, fs.ErrNotExist) {
-		return false
+		return false, nil
+	} else if marmotDirErr != nil {
+		return false, fmt.Errorf("%s: failed to stat Marmot directory; %w", marmotDir, marmotDirErr)
 	} else {
-		return true
+		return true, nil
 	}
 }

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -27,6 +27,7 @@ func (admin *JsonMetaRepoAdmin) Create(repositoryDir string) error {
 	} else if statErr != nil {
 		return fmt.Errorf("failed to check for existing meta repo %s; %w", repositoryDir, statErr)
 	} else {
+		//Ignore an existing meta repo, for now
 		return nil
 	}
 }

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -42,3 +42,20 @@ func initDirectory(metaDataFile string, rootObject *rootObjectData) error {
 		return nil
 	}
 }
+
+func (admin *JsonMetaRepoAdmin) IsMetaRepo(path string) bool {
+	pathStat, pathErr := os.Stat(path)
+	if errors.Is(pathErr, fs.ErrNotExist) || pathErr != nil {
+		return false
+	} else if pathStat.Mode().IsRegular() {
+		return false
+	}
+
+	marmotDir := metaDataDir(path)
+	_, marmotDirErr := os.Stat(marmotDir)
+	if errors.Is(marmotDirErr, fs.ErrNotExist) {
+		return false
+	} else {
+		return true
+	}
+}

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -46,7 +46,7 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 		})
 
 		It("ignores an existing directory already containing Marmot data", func() {
-			//What about the files inside of .marmot/?  Should those be re-created or left alone?
+			// What about the files inside of .marmot/?  Should those be re-created or left alone?
 			marmotDataDir := filepath.Join(testFsRoot, ".marmot")
 			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
 
@@ -123,6 +123,7 @@ func (args jsonMetaRepoAdminArgs) Version() string {
 /* Filesystem */
 
 func existingPath() string { return testFsRoot }
+
 func someFile() (string, error) {
 	path := filepath.Join(testFsRoot, "existing-file")
 	if aFile, createErr := os.Create(path); createErr != nil {

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -92,6 +92,11 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 
 			Expect(subject.IsMetaRepo(testFsRoot)).To(Equal(true))
 		})
+
+		It("returns an error, when checking that path fails", func() {
+			_, err := subject.IsMetaRepo("\000x")
+			Expect(err).To(MatchError(ContainSubstring("failed to stat meta repo path")))
+		})
 	})
 })
 

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -12,25 +12,22 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var testFsRoot string
+
 var _ = Describe("JsonMetaRepoAdmin", func() {
-	var (
-		subject      *svcfs.JsonMetaRepoAdmin
-		metaRepoPath string
-		testFsRoot   string
-	)
+	var subject *svcfs.JsonMetaRepoAdmin
 
 	BeforeEach(func() {
 		testFsRoot = expect.NoError(os.MkdirTemp("", "JsonMetaDataRepo-"))
-		metaRepoPath = filepath.Join(testFsRoot, "meta")
 		DeferCleanup(os.RemoveAll, testFsRoot)
 	})
 
 	Describe("#Create", func() {
 		It("creates files in the directory, given a valid, writable path", func() {
 			subject = jsonMetaRepoAdmin(nil)
-			subject.Create(metaRepoPath)
+			subject.Create(testFsRoot)
 
-			metaDataDir := filepath.Join(metaRepoPath, ".marmot")
+			metaDataDir := filepath.Join(testFsRoot, ".marmot")
 			Expect(os.Stat(metaDataDir)).NotTo(BeNil())
 
 			metaDataFile := filepath.Join(metaDataDir, "meta-repo.json")
@@ -39,22 +36,22 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 
 		It("returns no error, upon success", func() {
 			subject = jsonMetaRepoAdmin(nil)
-			Expect(subject.Create(metaRepoPath)).To(Succeed())
+			Expect(subject.Create(testFsRoot)).To(Succeed())
 		})
 
 		It("accepts an existing directory that is not a Marmot repo", func() {
-			Expect(os.MkdirAll(metaRepoPath, fs.ModePerm)).To(Succeed())
+			Expect(os.MkdirAll(testFsRoot, fs.ModePerm)).To(Succeed())
 			subject = jsonMetaRepoAdmin(nil)
-			Expect(subject.Create(metaRepoPath)).To(Succeed())
+			Expect(subject.Create(testFsRoot)).To(Succeed())
 		})
 
 		It("ignores an existing directory already containing Marmot data", func() {
 			//What about the files inside of .marmot/?  Should those be re-created or left alone?
-			marmotDataDir := filepath.Join(metaRepoPath, ".marmot")
+			marmotDataDir := filepath.Join(testFsRoot, ".marmot")
 			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
 
 			subject = jsonMetaRepoAdmin(nil)
-			Expect(subject.Create(metaRepoPath)).To(Succeed())
+			Expect(subject.Create(testFsRoot)).To(Succeed())
 		})
 
 		It("returns an error, given an invalid path", func() {
@@ -66,16 +63,35 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 		It("returns an error, given a path in which files can not be created", func() {
 			Expect(os.Chmod(testFsRoot, 0o555)).To(Succeed())
 			subject = jsonMetaRepoAdmin(nil)
-			Expect(subject.Create(metaRepoPath)).To(
+			Expect(subject.Create(testFsRoot)).To(
 				MatchError(MatchRegexp("failed to make directory")))
 		})
 	})
 
 	Describe("#IsMetaRepo", func() {
-		It("returns false, given a non-existent path", Pending)
-		It("returns false, given an existing path that is not a directory", Pending)
-		It("returns false, given a directory not containing a Marmot metadata", Pending)
-		It("returns true, given a directory containing Marmot metadata", Pending)
+		BeforeEach(func() {
+			subject = jsonMetaRepoAdmin(nil)
+		})
+
+		It("returns false, given a non-existent path", func() {
+			Expect(subject.IsMetaRepo(nonExistentPath())).To(Equal(false))
+		})
+
+		It("returns false, given an existing path that is not a directory", func() {
+			existingFile := expect.NoError(someFile())
+			Expect(subject.IsMetaRepo(existingFile)).To(Equal(false))
+		})
+
+		It("returns false, given a directory not containing a Marmot metadata", func() {
+			Expect(subject.IsMetaRepo(existingPath())).To(Equal(false))
+		})
+
+		It("returns true, given a directory containing Marmot metadata", func() {
+			marmotDataDir := filepath.Join(testFsRoot, ".marmot")
+			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
+
+			Expect(subject.IsMetaRepo(testFsRoot)).To(Equal(true))
+		})
 	})
 })
 
@@ -98,3 +114,18 @@ func (args jsonMetaRepoAdminArgs) Version() string {
 		return args.version
 	}
 }
+
+/* Filesystem */
+
+func existingPath() string { return testFsRoot }
+func someFile() (string, error) {
+	path := filepath.Join(testFsRoot, "existing-file")
+	if aFile, createErr := os.Create(path); createErr != nil {
+		return "", createErr
+	} else {
+		defer aFile.Close()
+		return path, nil
+	}
+}
+
+func nonExistentPath() string { return filepath.Join(testFsRoot, "not-created-yet") }

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -34,7 +34,7 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 			Expect(subject.Create(metaRepoPath)).To(Succeed())
 		})
 
-		It("returns an error, given a path containing marmot data", func() {
+		It("returns an error, given a path containing marmot data", Pending, func() {
 			marmotDataDir := filepath.Join(metaRepoPath, ".marmot")
 			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
 

--- a/src/go/svcfs/json_meta_repo_admin_test.go
+++ b/src/go/svcfs/json_meta_repo_admin_test.go
@@ -34,13 +34,13 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 			Expect(subject.Create(metaRepoPath)).To(Succeed())
 		})
 
-		It("returns an error, given a path containing marmot data", Pending, func() {
+		It("leaves the existing directory, given a path that is already a meta repo", func() {
+			//TODO KDK: What about the files inside of .marmot/?  Should those be re-created?
 			marmotDataDir := filepath.Join(metaRepoPath, ".marmot")
 			Expect(os.MkdirAll(marmotDataDir, fs.ModePerm)).To(Succeed())
 
 			subject = jsonMetaRepoAdmin(nil)
-			Expect(subject.Create(metaRepoPath)).To(
-				MatchError(fmt.Sprintf("path already exists: %s", marmotDataDir)))
+			Expect(subject.Create(metaRepoPath)).To(Succeed())
 		})
 
 		It("returns an error when unable to check if the path exists", func() {
@@ -67,6 +67,13 @@ var _ = Describe("JsonMetaRepoAdmin", func() {
 			metaDataFile := filepath.Join(metaDataDir, "meta-repo.json")
 			Expect(os.Stat(metaDataFile)).NotTo(BeNil())
 		})
+	})
+
+	Describe("#IsMetaRepo", func() {
+		It("returns false, given a non-existent path", Pending)
+		It("returns false, given an existing path that is not a directory", Pending)
+		It("returns false, given a directory not containing a Marmot metadata", Pending)
+		It("returns true, given a directory containing Marmot metadata", Pending)
 	})
 })
 

--- a/src/go/usemetarepo/init_command.go
+++ b/src/go/usemetarepo/init_command.go
@@ -12,8 +12,10 @@ type InitCommand struct {
 }
 
 func (cmd InitCommand) Run(metaRepoPath string) error {
-	if cmd.MetaDataAdmin.IsMetaRepo(metaRepoPath) {
-		return fmt.Errorf("%s is already a meta repo", metaRepoPath)
+	if isMetaRepo, isMetaRepoErr := cmd.MetaDataAdmin.IsMetaRepo(metaRepoPath); isMetaRepoErr != nil {
+		return fmt.Errorf("%s: unable to check path; %w", metaRepoPath, isMetaRepoErr)
+	} else if isMetaRepo {
+		return fmt.Errorf("%s: already a meta repo", metaRepoPath)
 	} else if createErr := cmd.MetaDataAdmin.Create(metaRepoPath); createErr != nil {
 		return fmt.Errorf("failed to initialize meta repo; %w", createErr)
 	} else {

--- a/src/go/usemetarepo/init_command.go
+++ b/src/go/usemetarepo/init_command.go
@@ -1,6 +1,8 @@
 package usemetarepo
 
-import core "github.com/kkrull/marmot/coremetarepo"
+import (
+	core "github.com/kkrull/marmot/coremetarepo"
+)
 
 // Initializes a new meta repo where none existed before.
 type InitCommand struct {

--- a/src/go/usemetarepo/init_command.go
+++ b/src/go/usemetarepo/init_command.go
@@ -1,6 +1,8 @@
 package usemetarepo
 
 import (
+	"fmt"
+
 	core "github.com/kkrull/marmot/coremetarepo"
 )
 
@@ -10,5 +12,11 @@ type InitCommand struct {
 }
 
 func (cmd InitCommand) Run(metaRepoPath string) error {
-	return cmd.MetaDataAdmin.Create(metaRepoPath)
+	if cmd.MetaDataAdmin.Exists(metaRepoPath) {
+		return fmt.Errorf("%s is already a meta repo", metaRepoPath)
+	} else if createErr := cmd.MetaDataAdmin.Create(metaRepoPath); createErr != nil {
+		return fmt.Errorf("failed to initialize meta repo; %w", createErr)
+	} else {
+		return nil
+	}
 }

--- a/src/go/usemetarepo/init_command.go
+++ b/src/go/usemetarepo/init_command.go
@@ -12,7 +12,7 @@ type InitCommand struct {
 }
 
 func (cmd InitCommand) Run(metaRepoPath string) error {
-	if cmd.MetaDataAdmin.Exists(metaRepoPath) {
+	if cmd.MetaDataAdmin.IsMetaRepo(metaRepoPath) {
 		return fmt.Errorf("%s is already a meta repo", metaRepoPath)
 	} else if createErr := cmd.MetaDataAdmin.Create(metaRepoPath); createErr != nil {
 		return fmt.Errorf("failed to initialize meta repo; %w", createErr)

--- a/src/go/usemetarepo/init_command_test.go
+++ b/src/go/usemetarepo/init_command_test.go
@@ -38,11 +38,11 @@ var _ = Describe("InitCommand", func() {
 	Describe("#Run", func() {
 		It("creates a meta repo in that path", func() {
 			givenPath := validPath()
-			Expect(subject.Run(givenPath)).To(Succeed())
+			subject.Run(givenPath)
 			metaDataAdmin.CreateExpected(givenPath)
 		})
 
-		It("returns a nil error, when that succeeds", func() {
+		It("returns no error, upon success", func() {
 			Expect(subject.Run(validPath())).To(Succeed())
 		})
 

--- a/src/go/usemetarepo/init_command_test.go
+++ b/src/go/usemetarepo/init_command_test.go
@@ -51,11 +51,18 @@ var _ = Describe("InitCommand", func() {
 			Expect(subject.Run(nonExistentPath())).To(Succeed())
 		})
 
+		It("returns an error when unable to check the path", func() {
+			path := filepath.Join(testDir, "stealth")
+			metaDataAdmin.IsMetaRepoReturns(path, false, errors.New("bang!"))
+			Expect(subject.Run(path)).To(
+				MatchError(ContainSubstring("stealth: unable to check path; bang!")))
+		})
+
 		It("returns an error when the path is already a meta repo", func() {
 			existingMetaRepo := filepath.Join(testDir, "meta-already")
-			metaDataAdmin.IsMetaRepoReturns(existingMetaRepo, true)
+			metaDataAdmin.IsMetaRepoReturns(existingMetaRepo, true, nil)
 			Expect(subject.Run(existingMetaRepo)).To(
-				MatchError(MatchRegexp("meta-already is already a meta repo$")))
+				MatchError(MatchRegexp("meta-already: already a meta repo$")))
 		})
 
 		It("returns an error when creating a meta repo fails", func() {

--- a/src/go/usemetarepo/init_command_test.go
+++ b/src/go/usemetarepo/init_command_test.go
@@ -2,6 +2,7 @@ package usemetarepo_test
 
 import (
 	"errors"
+	"os"
 
 	mock "github.com/kkrull/marmot/coremetarepomock"
 	expect "github.com/kkrull/marmot/testsupportexpect"
@@ -16,15 +17,34 @@ var _ = Describe("InitCommand", func() {
 	var (
 		subject       *usemetarepo.InitCommand
 		metaDataAdmin *mock.MetaDataAdmin
+		testDir       string
 	)
 
 	BeforeEach(func() {
+		testDir = expect.NoError(os.MkdirTemp("", "InitCommand-"))
+		DeferCleanup(os.RemoveAll, testDir)
+
 		metaDataAdmin = mock.NewMetaDataAdmin()
 		factory := use.NewCommandFactory().WithMetaDataAdmin(metaDataAdmin)
 		subject = expect.NoError(factory.NewInitMetaRepo())
 	})
 
-	Describe("#Run", func() {
+	Describe("#Run (new interface)", func() {
+		It("creates a meta repo in that path", Pending, func() {})
+		It("returns a nil error, when that succeeds", Pending, func() {})
+		It("allows a meta repo to be created in an existing directory", Pending, func() {})
+		It("returns an error when the path is already a meta repo", Pending, func() {})
+		It("returns an error when creating a meta repo fails", Pending, func() {})
+	})
+
+	Describe("#Run (old interface)", func() {
+		It("returns an error when t˝he path already contains a meta repo", Pending, func() {
+			metaDataAdmin.ExistsReturns(testDir, true)
+
+			Expect(subject.Run(testDir)).To(
+				MatchError(MatchRegexp("^InitCommand.*: already a meta repo$")))
+		})
+
 		It("initializes the given meta data source", func() {
 			_ = subject.Run("/tmp")
 			metaDataAdmin.CreateExpected("/tmp")

--- a/src/go/usemetarepo/init_command_test.go
+++ b/src/go/usemetarepo/init_command_test.go
@@ -3,6 +3,7 @@ package usemetarepo_test
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	mock "github.com/kkrull/marmot/coremetarepomock"
 	expect "github.com/kkrull/marmot/testsupportexpect"
@@ -13,11 +14,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var testDir string
+
+func existingPath() string    { return testDir }
+func nonExistentPath() string { return filepath.Join(testDir, "not-created-yet") }
+func validPath() string       { return filepath.Join(testDir, "meta-default") }
+
 var _ = Describe("InitCommand", func() {
 	var (
 		subject       *usemetarepo.InitCommand
 		metaDataAdmin *mock.MetaDataAdmin
-		testDir       string
 	)
 
 	BeforeEach(func() {
@@ -29,34 +35,34 @@ var _ = Describe("InitCommand", func() {
 		subject = expect.NoError(factory.NewInitMetaRepo())
 	})
 
-	Describe("#Run (new interface)", func() {
-		It("creates a meta repo in that path", Pending, func() {})
-		It("returns a nil error, when that succeeds", Pending, func() {})
-		It("allows a meta repo to be created in an existing directory", Pending, func() {})
-		It("returns an error when the path is already a meta repo", Pending, func() {})
-		It("returns an error when creating a meta repo fails", Pending, func() {})
-	})
-
-	Describe("#Run (old interface)", func() {
-		It("returns an error when t˝he path already contains a meta repo", Pending, func() {
-			metaDataAdmin.ExistsReturns(testDir, true)
-
-			Expect(subject.Run(testDir)).To(
-				MatchError(MatchRegexp("^InitCommand.*: already a meta repo$")))
+	Describe("#Run", func() {
+		It("creates a meta repo in that path", func() {
+			givenPath := validPath()
+			Expect(subject.Run(givenPath)).To(Succeed())
+			metaDataAdmin.CreateExpected(givenPath)
 		})
 
-		It("initializes the given meta data source", func() {
-			_ = subject.Run("/tmp")
-			metaDataAdmin.CreateExpected("/tmp")
+		It("returns a nil error, when that succeeds", func() {
+			Expect(subject.Run(validPath())).To(Succeed())
 		})
 
-		It("returns nil, when everything succeeds", func() {
-			Expect(subject.Run("/tmp")).To(BeNil())
+		It("accepts paths that do and do not exist, provided a meta repo is not there", func() {
+			Expect(subject.Run(existingPath())).To(Succeed())
+			Expect(subject.Run(nonExistentPath())).To(Succeed())
 		})
 
-		It("returns an error when failing to initialize the meta data source", func() {
+		It("returns an error when the path is already a meta repo", func() {
+			existingMetaRepo := filepath.Join(testDir, "meta-already")
+			metaDataAdmin.ExistsReturns(existingMetaRepo, true)
+
+			Expect(subject.Run(existingMetaRepo)).To(
+				MatchError(MatchRegexp("meta-already is already a meta repo$")))
+		})
+
+		It("returns an error when creating a meta repo fails", func() {
 			metaDataAdmin.CreateFails(errors.New("bang!"))
-			Expect(subject.Run("/tmp")).To(MatchError("bang!"))
+			Expect(subject.Run(validPath())).To(
+				MatchError(MatchRegexp("^failed to initialize meta repo.*bang!$")))
 		})
 	})
 })

--- a/src/go/usemetarepo/init_command_test.go
+++ b/src/go/usemetarepo/init_command_test.go
@@ -53,8 +53,7 @@ var _ = Describe("InitCommand", func() {
 
 		It("returns an error when the path is already a meta repo", func() {
 			existingMetaRepo := filepath.Join(testDir, "meta-already")
-			metaDataAdmin.ExistsReturns(existingMetaRepo, true)
-
+			metaDataAdmin.IsMetaRepoReturns(existingMetaRepo, true)
 			Expect(subject.Run(existingMetaRepo)).To(
 				MatchError(MatchRegexp("meta-already is already a meta repo$")))
 		})


### PR DESCRIPTION
# Changes

## Primary change

Move business logic for initializing a meta repo to the init command.

## Supporting changes

Build artifacts on CI in GitHub Actions

## Future work

the other commands
