### PR TITLE
Separate local data

### DIFF
--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -30,7 +30,6 @@ func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
 		Use:     "local",
 	}
 
-	// TODO KDK: Use a separate .marmot/meta-repo-local.json file
 	cmdlocal.NewListCommand().AddToCobra(localCobraCmd)
 	cmdlocal.NewRegisterCommand().AddToCobra(localCobraCmd)
 	return localCobraCmd

--- a/src/go/cmd/local.go
+++ b/src/go/cmd/local.go
@@ -30,6 +30,7 @@ func (cliCmd *localCommand) toCobraCommand() *cobra.Command {
 		Use:     "local",
 	}
 
+	// TODO KDK: Use a separate .marmot/meta-repo-local.json file
 	cmdlocal.NewListCommand().AddToCobra(localCobraCmd)
 	cmdlocal.NewRegisterCommand().AddToCobra(localCobraCmd)
 	return localCobraCmd

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -40,7 +40,7 @@ func (parser rootConfigParser) Parse(
 		return nil, pathErr
 	} else {
 		metaRepoAdmin := svcfs.NewJsonMetaRepoAdmin(parser.version)
-		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
+		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath) // TODO KDK: Work here - add another version that works on a .local file
 		config := &rootCliConfig{
 			args: args,
 			cmdFactory: use.NewCommandFactory().

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -44,8 +44,9 @@ func (parser rootConfigParser) Parse(
 		config := &rootCliConfig{
 			args: args,
 			cmdFactory: use.NewCommandFactory().
+				WithLocalRepositorySource(jsonMetaRepo).
 				WithMetaDataAdmin(metaRepoAdmin).
-				WithRepositorySource(jsonMetaRepo),
+				WithRemoteRepositorySource(jsonMetaRepo),
 			debug:        debug,
 			flagSet:      flags,
 			inputLines:   make([]string, 0),
@@ -96,8 +97,9 @@ func (parser rootConfigParser) ParseR(
 		config := &rootCliConfig{
 			args: argsBeforeDash,
 			cmdFactory: use.NewCommandFactory().
+				WithLocalRepositorySource(jsonMetaRepo).
 				WithMetaDataAdmin(metaRepoAdmin).
-				WithRepositorySource(jsonMetaRepo),
+				WithRemoteRepositorySource(jsonMetaRepo),
 			debug:        debug,
 			flagSet:      flags,
 			inputLines:   inputLines,

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -51,6 +51,7 @@ func (parser rootConfigParser) Parse(
 			inputLines:   make([]string, 0),
 			metaRepoPath: metaRepoPath,
 			queryFactory: use.NewQueryFactory().
+				WithLocalRepositorySource(jsonMetaRepo).
 				WithMetaDataAdmin(metaRepoAdmin).
 				WithRepositorySource(jsonMetaRepo),
 		}

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -40,7 +40,7 @@ func (parser rootConfigParser) Parse(
 		return nil, pathErr
 	} else {
 		metaRepoAdmin := svcfs.NewJsonMetaRepoAdmin(parser.version)
-		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath) // TODO KDK: Work here - add another version that works on a .local file
+		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
 		config := &rootCliConfig{
 			args: args,
 			cmdFactory: use.NewCommandFactory().

--- a/src/go/cmd/root/cli_config_parser.go
+++ b/src/go/cmd/root/cli_config_parser.go
@@ -53,7 +53,7 @@ func (parser rootConfigParser) Parse(
 			queryFactory: use.NewQueryFactory().
 				WithLocalRepositorySource(jsonMetaRepo).
 				WithMetaDataAdmin(metaRepoAdmin).
-				WithRepositorySource(jsonMetaRepo),
+				WithRemoteRepositorySource(jsonMetaRepo),
 		}
 
 		return config, nil
@@ -103,8 +103,9 @@ func (parser rootConfigParser) ParseR(
 			inputLines:   inputLines,
 			metaRepoPath: metaRepoPath,
 			queryFactory: use.NewQueryFactory().
+				WithLocalRepositorySource(jsonMetaRepo).
 				WithMetaDataAdmin(metaRepoAdmin).
-				WithRepositorySource(jsonMetaRepo),
+				WithRemoteRepositorySource(jsonMetaRepo),
 		}
 
 		return config, nil

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -2,7 +2,7 @@ package corerepository
 
 import "net/url"
 
-// A source of Git repositories that a meta repo might care about.
+// A source of Git repositories on this machine that a meta repo might care about.
 //
 // Repository sources are responsible for these invariants:
 //   - Local repository paths are distinct, by string comparison.  Clients decide whether to
@@ -15,12 +15,10 @@ type LocalRepositorySource interface {
 	ListLocal() (Repositories, error)
 }
 
-// A source of Git repositories that a meta repo might care about.
+// A source of Git repositories on other machines that a meta repo might care about.
 //
 // Repository sources are responsible for these invariants:
-//
-//	  resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
-//	- Remote repository URLs are distinct, comparing hrefs.
+//   - Remote repository URLs are distinct, comparing hrefs.
 type RemoteRepositorySource interface {
 	// Add repositories hosted at the specified URLs, skipping known remotes and duplicates.
 	AddRemotes(hostUrls []*url.URL) error

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -28,23 +28,3 @@ type RemoteRepositorySource interface {
 	// List all known repositories on remote hosts, including those that have not been cloned locally.
 	ListRemote() (Repositories, error)
 }
-
-// A source of Git repositories that a meta repo might care about.
-//
-// Repository sources are responsible for these invariants:
-//   - Local repository paths are distinct, by string comparison.  Clients decide whether to
-//     resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
-//   - Remote repository URLs are distinct, comparing hrefs.
-type RepositorySource interface {
-	// Add repositories located at the specified paths, skipping known paths and exact duplicates.
-	AddLocals(localPaths []string) error
-
-	// Add repositories hosted at the specified URLs, skipping known remotes and duplicates.
-	AddRemotes(hostUrls []*url.URL) error
-
-	// List all known repositories on the local file system, including remotes cloned to known paths.
-	ListLocal() (Repositories, error)
-
-	// List all known repositories on remote hosts, including those that have not been cloned locally.
-	ListRemote() (Repositories, error)
-}

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -18,6 +18,20 @@ type LocalRepositorySource interface {
 // A source of Git repositories that a meta repo might care about.
 //
 // Repository sources are responsible for these invariants:
+//
+//	  resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
+//	- Remote repository URLs are distinct, comparing hrefs.
+type RemoteRepositorySource interface {
+	// Add repositories hosted at the specified URLs, skipping known remotes and duplicates.
+	AddRemotes(hostUrls []*url.URL) error
+
+	// List all known repositories on remote hosts, including those that have not been cloned locally.
+	ListRemote() (Repositories, error)
+}
+
+// A source of Git repositories that a meta repo might care about.
+//
+// Repository sources are responsible for these invariants:
 //   - Local repository paths are distinct, by string comparison.  Clients decide whether to
 //     resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
 //   - Remote repository URLs are distinct, comparing hrefs.

--- a/src/go/corerepository/repository_source.go
+++ b/src/go/corerepository/repository_source.go
@@ -7,6 +7,19 @@ import "net/url"
 // Repository sources are responsible for these invariants:
 //   - Local repository paths are distinct, by string comparison.  Clients decide whether to
 //     resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
+type LocalRepositorySource interface {
+	// Add repositories located at the specified paths, skipping known paths and exact duplicates.
+	AddLocals(localPaths []string) error
+
+	// List all known repositories on the local file system, including remotes cloned to known paths.
+	ListLocal() (Repositories, error)
+}
+
+// A source of Git repositories that a meta repo might care about.
+//
+// Repository sources are responsible for these invariants:
+//   - Local repository paths are distinct, by string comparison.  Clients decide whether to
+//     resolve relative paths or de-duplicate paths that resolve to the same filesystem entry.
 //   - Remote repository URLs are distinct, comparing hrefs.
 type RepositorySource interface {
 	// Add repositories located at the specified paths, skipping known paths and exact duplicates.

--- a/src/go/cukesupport/factory_helper.go
+++ b/src/go/cukesupport/factory_helper.go
@@ -27,6 +27,8 @@ func ThatQueryFactory() (use.QueryFactory, error) {
 		return nil, pathErr
 	} else {
 		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
-		return use.NewQueryFactory().WithRepositorySource(jsonMetaRepo), nil
+		return use.NewQueryFactory().
+			WithLocalRepositorySource(jsonMetaRepo).
+			WithRepositorySource(jsonMetaRepo), nil
 	}
 }

--- a/src/go/cukesupport/factory_helper.go
+++ b/src/go/cukesupport/factory_helper.go
@@ -11,7 +11,10 @@ func ThatCommandFactory() (use.CommandFactory, error) {
 		return nil, pathErr
 	} else {
 		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
-		return use.NewCommandFactory().WithRepositorySource(jsonMetaRepo), nil
+		return use.NewCommandFactory().
+				WithLocalRepositorySource(jsonMetaRepo).
+				WithRemoteRepositorySource(jsonMetaRepo),
+			nil
 	}
 }
 

--- a/src/go/cukesupport/factory_helper.go
+++ b/src/go/cukesupport/factory_helper.go
@@ -29,6 +29,6 @@ func ThatQueryFactory() (use.QueryFactory, error) {
 		jsonMetaRepo := svcfs.NewJsonMetaRepo(metaRepoPath)
 		return use.NewQueryFactory().
 			WithLocalRepositorySource(jsonMetaRepo).
-			WithRepositorySource(jsonMetaRepo), nil
+			WithRemoteRepositorySource(jsonMetaRepo), nil
 	}
 }

--- a/src/go/svcfs/json_meta_repo.go
+++ b/src/go/svcfs/json_meta_repo.go
@@ -9,12 +9,16 @@ import (
 )
 
 func NewJsonMetaRepo(repositoryPath string) *JsonMetaRepo {
-	return &JsonMetaRepo{metaDataFile: metaDataFile(repositoryPath)}
+	return &JsonMetaRepo{
+		localDataFile: localDataFile(repositoryPath),
+		metaDataFile:  metaDataFile(repositoryPath),
+	}
 }
 
 // A meta repo that stores meta data in JSON files in the specified directory.
 type JsonMetaRepo struct {
-	metaDataFile string
+	localDataFile string
+	metaDataFile  string
 }
 
 /* Local repositories */
@@ -39,14 +43,14 @@ func (repo *JsonMetaRepo) AddLocals(localPaths []string) error {
 }
 
 func (repo *JsonMetaRepo) addLocal(localPath string) error {
-	return repo.updateFile(func(rootObject *rootObjectData) {
+	return updateFile(repo.localDataFile, func(rootObject *rootObjectData) {
 		rootObject.MetaRepo.AppendLocalRepository(localRepositoryData{Path: localPath})
 	})
 }
 
 func (repo *JsonMetaRepo) ListLocal() (core.Repositories, error) {
 	return queryFile(
-		repo.metaDataFile,
+		repo.localDataFile,
 		core.NoRepositories(),
 		func(rootObject *rootObjectData) (core.Repositories, error) {
 			return rootObject.MetaRepo.MapLocalRepositories()
@@ -75,7 +79,7 @@ func (repo *JsonMetaRepo) AddRemotes(hostUrls []*url.URL) error {
 }
 
 func (repo *JsonMetaRepo) addRemote(hostUrl *url.URL) error {
-	return repo.updateFile(func(rootObject *rootObjectData) {
+	return updateFile(repo.metaDataFile, func(rootObject *rootObjectData) {
 		rootObject.MetaRepo.AppendRemoteRepository(remoteRepositoryData{Url: hostUrl.String()})
 	})
 }
@@ -92,12 +96,12 @@ func (repo *JsonMetaRepo) ListRemote() (core.Repositories, error) {
 /* I/O */
 
 func queryFile[V any](
-	metaDataFile string,
+	dataFile string,
 	defaultValue V,
 	queryData func(*rootObjectData) (V, error),
 ) (V, error) {
-	if rootObject, readErr := ReadMetaRepoFile(metaDataFile); readErr != nil {
-		return defaultValue, fmt.Errorf("failed to read file %s; %w", metaDataFile, readErr)
+	if rootObject, readErr := ReadMetaRepoFile(dataFile); readErr != nil {
+		return defaultValue, fmt.Errorf("failed to read file %s; %w", dataFile, readErr)
 	} else if result, queryErr := queryData(rootObject); queryErr != nil {
 		return defaultValue, fmt.Errorf("failed to query data; %w", queryErr)
 	} else {
@@ -107,16 +111,16 @@ func queryFile[V any](
 
 type updateDataFn = func(*rootObjectData)
 
-func (repo *JsonMetaRepo) updateFile(updateData updateDataFn) error {
+func updateFile(dataFile string, updateData updateDataFn) error {
 	var rootObject *rootObjectData
-	rootObject, readErr := ReadMetaRepoFile(repo.metaDataFile)
+	rootObject, readErr := ReadMetaRepoFile(dataFile)
 	if readErr != nil {
-		return fmt.Errorf("failed to read file %s; %w", repo.metaDataFile, readErr)
+		return fmt.Errorf("failed to read file %s; %w", dataFile, readErr)
 	}
 
 	updateData(rootObject)
-	if writeErr := rootObject.WriteTo(repo.metaDataFile); writeErr != nil {
-		return fmt.Errorf("failed to write file %s; %w", repo.metaDataFile, writeErr)
+	if writeErr := rootObject.WriteTo(dataFile); writeErr != nil {
+		return fmt.Errorf("failed to write file %s; %w", dataFile, writeErr)
 	} else {
 		return nil
 	}

--- a/src/go/svcfs/json_meta_repo_admin.go
+++ b/src/go/svcfs/json_meta_repo_admin.go
@@ -21,16 +21,19 @@ type JsonMetaRepoAdmin struct {
 
 func (admin *JsonMetaRepoAdmin) Create(repositoryDir string) error {
 	return initDirectory(
+		localDataFile(repositoryDir),
 		metaDataFile(repositoryDir),
 		InitMetaRepoData(admin.version))
 }
 
-func initDirectory(metaDataFile string, rootObject *rootObjectData) error {
+func initDirectory(localDataFile string, metaDataFile string, rootObject *rootObjectData) error {
 	metaDataDir := path.Dir(metaDataFile)
 	if dirErr := os.MkdirAll(metaDataDir, fs.ModePerm); dirErr != nil {
 		return fmt.Errorf("failed to make directory %s; %w", metaDataDir, dirErr)
+	} else if writeMetaDataErr := rootObject.WriteTo(metaDataFile); writeMetaDataErr != nil {
+		return fmt.Errorf("failed to write shared meta data file %s; %w", metaDataFile, writeMetaDataErr)
 	} else {
-		return rootObject.WriteTo(metaDataFile)
+		return rootObject.WriteTo(localDataFile)
 	}
 }
 

--- a/src/go/svcfs/paths.go
+++ b/src/go/svcfs/paths.go
@@ -7,7 +7,12 @@ func metaDataDir(metaRepoDir string) string {
 	return filepath.Join(metaRepoDir, ".marmot")
 }
 
-// Path to the specific file where Marmot store its data.
+// Path to the specific file where Marmot stores machine-specific data.
+func localDataFile(metaRepoDir string) string {
+	return filepath.Join(metaDataDir(metaRepoDir), "meta-repo-local.json")
+}
+
+// Path to the specific file where Marmot stores shared data.
 func metaDataFile(metaRepoDir string) string {
 	return filepath.Join(metaDataDir(metaRepoDir), "meta-repo.json")
 }

--- a/src/go/use/command_factory.go
+++ b/src/go/use/command_factory.go
@@ -21,25 +21,39 @@ type CommandFactory interface {
 }
 
 type cmdFactory struct {
-	MetaDataAdmin    coremetarepo.MetaDataAdmin
-	RepositorySource corerepository.RepositorySource
+	LocalRepositorySource  corerepository.LocalRepositorySource
+	MetaDataAdmin          coremetarepo.MetaDataAdmin
+	RemoteRepositorySource corerepository.RemoteRepositorySource
 }
 
-func (factory *cmdFactory) WithMetaDataAdmin(metadataAdmin coremetarepo.MetaDataAdmin) *cmdFactory {
-	factory.MetaDataAdmin = metadataAdmin
+func (factory *cmdFactory) WithLocalRepositorySource(source corerepository.LocalRepositorySource) *cmdFactory {
+	factory.LocalRepositorySource = source
 	return factory
 }
 
-func (factory *cmdFactory) WithRepositorySource(repositorySource corerepository.RepositorySource) *cmdFactory {
-	factory.RepositorySource = repositorySource
+func (factory *cmdFactory) WithMetaDataAdmin(admin coremetarepo.MetaDataAdmin) *cmdFactory {
+	factory.MetaDataAdmin = admin
 	return factory
 }
 
-func (factory *cmdFactory) repositorySource() (corerepository.RepositorySource, error) {
-	if factory.RepositorySource == nil {
-		return nil, errors.New("missing RepositorySource")
+func (factory *cmdFactory) WithRemoteRepositorySource(source corerepository.RemoteRepositorySource) *cmdFactory {
+	factory.RemoteRepositorySource = source
+	return factory
+}
+
+func (factory *cmdFactory) localRepositorySource() (corerepository.LocalRepositorySource, error) {
+	if factory.LocalRepositorySource == nil {
+		return nil, errors.New("missing LocalRepositorySource")
 	} else {
-		return factory.RepositorySource, nil
+		return factory.LocalRepositorySource, nil
+	}
+}
+
+func (factory *cmdFactory) remoteRepositorySource() (corerepository.RemoteRepositorySource, error) {
+	if factory.RemoteRepositorySource == nil {
+		return nil, errors.New("missing RemoteRepositorySource")
+	} else {
+		return factory.RemoteRepositorySource, nil
 	}
 }
 
@@ -58,19 +72,19 @@ func (factory *cmdFactory) NewInitMetaRepo() (*metarepo.InitCommand, error) {
 func (factory *cmdFactory) NewRegisterLocalRepositories() (
 	*repository.RegisterLocalRepositoriesCommand, error,
 ) {
-	if repositorySource, err := factory.repositorySource(); err != nil {
+	if source, err := factory.localRepositorySource(); err != nil {
 		return nil, err
 	} else {
-		return &repository.RegisterLocalRepositoriesCommand{Source: repositorySource}, nil
+		return &repository.RegisterLocalRepositoriesCommand{Source: source}, nil
 	}
 }
 
 func (factory *cmdFactory) NewRegisterRemoteRepositories() (
 	*repository.RegisterRemoteRepositoriesCommand, error,
 ) {
-	if repositorySource, err := factory.repositorySource(); err != nil {
+	if source, err := factory.remoteRepositorySource(); err != nil {
 		return nil, err
 	} else {
-		return &repository.RegisterRemoteRepositoriesCommand{Source: repositorySource}, nil
+		return &repository.RegisterRemoteRepositoriesCommand{Source: source}, nil
 	}
 }

--- a/src/go/use/query_factory.go
+++ b/src/go/use/query_factory.go
@@ -19,8 +19,14 @@ type QueryFactory interface {
 }
 
 type queryFactory struct {
-	MetaDataAdmin    coremetarepo.MetaDataAdmin
-	RepositorySource corerepository.RepositorySource
+	LocalRepositorySource corerepository.LocalRepositorySource
+	MetaDataAdmin         coremetarepo.MetaDataAdmin
+	RepositorySource      corerepository.RepositorySource
+}
+
+func (factory *queryFactory) WithLocalRepositorySource(source corerepository.LocalRepositorySource) *queryFactory {
+	factory.LocalRepositorySource = source
+	return factory
 }
 
 func (factory *queryFactory) WithMetaDataAdmin(admin coremetarepo.MetaDataAdmin) *queryFactory {
@@ -36,7 +42,7 @@ func (factory *queryFactory) WithRepositorySource(source corerepository.Reposito
 /* Repositories */
 
 func (factory *queryFactory) NewListLocalRepositories() (userepository.ListLocalRepositoriesQuery, error) {
-	if repositorySource, err := factory.repositorySource(); err != nil {
+	if repositorySource, err := factory.localRepositorySource(); err != nil {
 		return nil, err
 	} else {
 		return repositorySource.ListLocal, nil
@@ -48,6 +54,14 @@ func (factory *queryFactory) NewListRemoteRepositories() (userepository.ListRemo
 		return nil, err
 	} else {
 		return repositorySource.ListRemote, nil
+	}
+}
+
+func (factory *queryFactory) localRepositorySource() (corerepository.LocalRepositorySource, error) {
+	if factory.LocalRepositorySource == nil {
+		return nil, errors.New("missing LocalRepositorySource")
+	} else {
+		return factory.LocalRepositorySource, nil
 	}
 }
 

--- a/src/go/use/query_factory.go
+++ b/src/go/use/query_factory.go
@@ -14,7 +14,7 @@ func NewQueryFactory() *queryFactory {
 
 // Constructs application queries with configurable services.
 type QueryFactory interface {
-	NewListLocalRepositories() (userepository.ListRemoteRepositoriesQuery, error)
+	NewListLocalRepositories() (userepository.ListLocalRepositoriesQuery, error)
 	NewListRemoteRepositories() (userepository.ListRemoteRepositoriesQuery, error)
 }
 
@@ -35,7 +35,7 @@ func (factory *queryFactory) WithRepositorySource(source corerepository.Reposito
 
 /* Repositories */
 
-func (factory *queryFactory) NewListLocalRepositories() (userepository.ListRemoteRepositoriesQuery, error) {
+func (factory *queryFactory) NewListLocalRepositories() (userepository.ListLocalRepositoriesQuery, error) {
 	if repositorySource, err := factory.repositorySource(); err != nil {
 		return nil, err
 	} else {

--- a/src/go/use/query_factory.go
+++ b/src/go/use/query_factory.go
@@ -19,9 +19,9 @@ type QueryFactory interface {
 }
 
 type queryFactory struct {
-	LocalRepositorySource corerepository.LocalRepositorySource
-	MetaDataAdmin         coremetarepo.MetaDataAdmin
-	RepositorySource      corerepository.RepositorySource
+	LocalRepositorySource  corerepository.LocalRepositorySource
+	MetaDataAdmin          coremetarepo.MetaDataAdmin
+	RemoteRepositorySource corerepository.RemoteRepositorySource
 }
 
 func (factory *queryFactory) WithLocalRepositorySource(source corerepository.LocalRepositorySource) *queryFactory {
@@ -34,8 +34,8 @@ func (factory *queryFactory) WithMetaDataAdmin(admin coremetarepo.MetaDataAdmin)
 	return factory
 }
 
-func (factory *queryFactory) WithRepositorySource(source corerepository.RepositorySource) *queryFactory {
-	factory.RepositorySource = source
+func (factory *queryFactory) WithRemoteRepositorySource(source corerepository.RemoteRepositorySource) *queryFactory {
+	factory.RemoteRepositorySource = source
 	return factory
 }
 
@@ -50,7 +50,7 @@ func (factory *queryFactory) NewListLocalRepositories() (userepository.ListLocal
 }
 
 func (factory *queryFactory) NewListRemoteRepositories() (userepository.ListRemoteRepositoriesQuery, error) {
-	if repositorySource, err := factory.repositorySource(); err != nil {
+	if repositorySource, err := factory.remoteRepositorySource(); err != nil {
 		return nil, err
 	} else {
 		return repositorySource.ListRemote, nil
@@ -65,10 +65,10 @@ func (factory *queryFactory) localRepositorySource() (corerepository.LocalReposi
 	}
 }
 
-func (factory *queryFactory) repositorySource() (corerepository.RepositorySource, error) {
-	if factory.RepositorySource == nil {
-		return nil, errors.New("missing RepositorySource")
+func (factory *queryFactory) remoteRepositorySource() (corerepository.RemoteRepositorySource, error) {
+	if factory.RemoteRepositorySource == nil {
+		return nil, errors.New("missing RemoteRepositorySource")
 	} else {
-		return factory.RepositorySource, nil
+		return factory.RemoteRepositorySource, nil
 	}
 }

--- a/src/go/userepository/register_local_repositories_command.go
+++ b/src/go/userepository/register_local_repositories_command.go
@@ -9,7 +9,7 @@ import (
 
 // Registers Git repositories with the meta repo, based upon their paths on the local filesystem.
 type RegisterLocalRepositoriesCommand struct {
-	Source core.RepositorySource
+	Source core.LocalRepositorySource
 }
 
 func (cmd *RegisterLocalRepositoriesCommand) Run(localPaths []string) error {

--- a/src/go/userepository/register_local_repositories_command_test.go
+++ b/src/go/userepository/register_local_repositories_command_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RegisterLocalRepositoriesCommand", func() {
 		pathBuilder = expect.NoError(dirFixture.PathBuilder())
 
 		source = mock.NewRepositorySource()
-		factory := use.NewCommandFactory().WithRepositorySource(source)
+		factory := use.NewCommandFactory().WithLocalRepositorySource(source)
 		subject = expect.NoError(factory.NewRegisterLocalRepositories())
 	})
 

--- a/src/go/userepository/register_remote_repositories_command.go
+++ b/src/go/userepository/register_remote_repositories_command.go
@@ -9,7 +9,7 @@ import (
 
 // Registers Git repositories with the meta repo, based upon the address(es) of their remote hosts.
 type RegisterRemoteRepositoriesCommand struct {
-	Source core.RepositorySource
+	Source core.RemoteRepositorySource
 }
 
 func (cmd *RegisterRemoteRepositoriesCommand) Run(remoteUrls []*url.URL) error {

--- a/src/go/userepository/register_remote_repositories_command_test.go
+++ b/src/go/userepository/register_remote_repositories_command_test.go
@@ -24,7 +24,7 @@ var _ = Describe("RegisterRemoteRepositoriesCommand", func() {
 
 	BeforeEach(func() {
 		source = mock.NewRepositorySource()
-		factory := use.NewCommandFactory().WithRepositorySource(source)
+		factory := use.NewCommandFactory().WithRemoteRepositorySource(source)
 		subject = expect.NoError(factory.NewRegisterRemoteRepositories())
 	})
 


### PR DESCRIPTION
## Primary change

Move local repositories to `.marmot/meta-repo-local.json`, since paths are machine-specific.

## Future work

Remove unused portions of JSON data from each file, to avoid confusion.  But this will lead to splitting up more code than I wanted to put in this one PR.
